### PR TITLE
Fix string representation of jdatetime.datetime

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.8.1
+2016-02-29
+	* Fix string representation of jdatetime.datetime
+
 1.8.0
 2016-02-27
 	* Change the result locale base on locale set in locale.setlocale

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -10,7 +10,7 @@ from jdatetime.jalali import \
     GregorianToJalali, JalaliToGregorian, j_days_in_month
 import re as _re
 import locale as _locale
-__VERSION__ = "1.8.0"
+__VERSION__ = "1.8.1"
 MINYEAR = 1
 MAXYEAR = 9377
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -1107,4 +1107,4 @@ class datetime(date):
         else:
             mil = "." + mil
         tz = self.strftime("%z")
-        return self.strftime("%Y-%m-%d%H:%M:%S") + "%s%s" % (mil, tz)
+        return self.strftime("%Y-%m-%d %H:%M:%S") + "%s%s" % (mil, tz)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
         name='jdatetime',
-        version='1.8.0',
+        version='1.8.1',
         packages=['jdatetime',],
         license='Python Software Foundation License',
         keywords='Jalali implementation of Python datetime',

--- a/t/test.py
+++ b/t/test.py
@@ -328,5 +328,9 @@ class TestJDateTime(unittest.TestCase):
 
         self.assertEqual(day_of_week, u"دوشنبه")
 
+    def test_datetime_to_str(self):
+        date = jdatetime.datetime(1394, 1, 1, 0, 0, 0)
+        self.assertEqual(str(date), "1394-01-01 00:00:00")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It should be like `1394-01-01 00:00:00`