### PR TITLE
Problem: locale formatting fails on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ build: false
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python32"
     - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python32"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+
+test_script:
+  - "%PYTHON%\\python.exe t/test.py"

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -6,6 +6,7 @@
 from __future__ import unicode_literals
 import datetime as py_datetime
 import sys
+import platform
 from jdatetime.jalali import \
     GregorianToJalali, JalaliToGregorian, j_days_in_month
 import re as _re
@@ -22,7 +23,10 @@ if sys.version_info[0] >= 3:  # py3
 else:
     _int_types = (int, long)
 
-FA_LOCALE = 'fa_IR'
+if platform.system() == 'Windows':
+    FA_LOCALE = 'Persian_Iran'
+else:
+    FA_LOCALE = 'fa_IR'
 
 
 class time(py_datetime.time):

--- a/t/test.py
+++ b/t/test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 import datetime
+import platform
 import time
 import os
 import sys
@@ -328,10 +329,16 @@ class TestJDateTime(unittest.TestCase):
         self.assertEqual(day_of_week, "Mon")
 
     def test_with_fa_locale(self):
-        locale.setlocale(locale.LC_ALL, "fa_IR")
+        self.set_fa_locale()
         day_of_week = jdatetime.date(1395, 1, 2).strftime("%a")
 
         self.assertEqual(day_of_week, u"دوشنبه")
+
+    def set_fa_locale(self):
+        if platform.system() == 'Windows':
+            locale.setlocale(locale.LC_ALL, 'Persian')
+        else:
+            locale.setlocale(locale.LC_ALL, "fa_IR")
 
     def test_datetime_to_str(self):
         date = jdatetime.datetime(1394, 1, 1, 0, 0, 0)

--- a/t/test.py
+++ b/t/test.py
@@ -323,10 +323,16 @@ class TestJDateTime(unittest.TestCase):
         self.assertEqual(day_diff, datetime.timedelta(-365))
 
     def test_with_none_locale_set(self):
-        locale.resetlocale()
+        self.reset_locale()
         day_of_week = jdatetime.date(1395, 1, 2).strftime("%a")
 
         self.assertEqual(day_of_week, "Mon")
+
+    def reset_locale(self):
+        if platform.system() == 'Windows':
+            locale.setlocale(locale.LC_ALL, 'English_United States')
+        else:
+            locale.resetlocale()
 
     def test_with_fa_locale(self):
         self.set_fa_locale()


### PR DESCRIPTION
Solution: add platform specific formatting + tests

There is also an appveyor file included that I used for Windows testing. On Windows I had to patch `jdatetime` to make it work: `jdatetime.date._is_fa_locale = lambda self: True`.