### PR TITLE
Set default date/datetime locales per thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.pyc
 build
 *.swp
+
+.tags
+tags

--- a/README.rst
+++ b/README.rst
@@ -25,25 +25,26 @@ This module exactly follows Python Standard datetime module's methods http://doc
 
 Also these methods are addedd to jdatetime.date and jdatetime.datetime :
 
-.. code::
 
-    |  fromgregorian(**kw)
-    |      Convert gregorian to jalali and return jdatetime.date
-    |      jdatetime.date.fromgregorian(day=X,month=X,year=X)
-    |      jdatetime.date.fromgregorian(date=datetime.date)
-    |      jdatetime.date.fromgregorian(datetime=datetime.datetime)
-    |  togregorian(self)
-    |      Convert current jalali date to gregorian and return datetime.date
-    |  isleap(self)
-    |      check if year is leap year
-    |      algortim is based on http://en.wikipedia.org/wiki/Leap_year
+.. code-block:: python
+
+    fromgregorian(**kw)
+        Convert gregorian to jalali and return jdatetime.date
+        jdatetime.date.fromgregorian(day=X,month=X,year=X)
+        jdatetime.date.fromgregorian(date=datetime.date)
+        jdatetime.date.fromgregorian(datetime=datetime.datetime)
+    togregorian(self)
+        Convert current jalali date to gregorian and return datetime.date
+    isleap(self)
+        check if year is leap year
+        algortim is based on http://en.wikipedia.org/wiki/Leap_year
 
 
 
 Example
 -------
 
-.. code:: shell
+.. code-block:: shell
 
     $ python
     Python 2.6.6 (r266:84292, Sep 15 2010, 15:52:39)
@@ -56,11 +57,12 @@ Example
     >>> jdatetime.date.today()
     jdatetime.date(1394, 12, 4)
 
+
 Locale
 ------
 In order to get the date string in farsi you need to set the locale to fa_IR
 
-.. code:: shell
+.. code-block:: shell
 
     $ python
     Python 2.7.9 (default, Mar  1 2015, 12:57:24)
@@ -75,5 +77,20 @@ In order to get the date string in farsi you need to set the locale to fa_IR
     'fa_IR'
     >>> jdatetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S")
     u'\u0686\u0647\u0627\u0631\u0634\u0646\u0628\u0647, 08 \u0627\u0631\u062f\u06cc\u0628\u0647\u0634\u062a 1395 20:47:56'
+
+
+If your requirements demand to support different locales withing the same process,
+you could set the default locale per thread. New `date` and `datetime` instances
+created in each thread, will use the specified locale by default.
+This supports both Python threads, and greenlets.
+
+
+.. code-block:: python
+
+    import jdatetime
+    jdatetime.set_locale('fa_IR')
+    jdatetime.datetime.now().strftime('%A %B')
+    # u'\u062f\u0648\u0634\u0646\u0628\u0647 \u062e\u0631\u062f\u0627\u062f'
+
 
 .. _Jalali: http://en.wikipedia.org/wiki/Iranian_calendar

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -11,12 +11,15 @@ import locale as _locale
 import re as _re
 
 try:
-    from _thread import get_ident
+    from greenlet import getcurrent as get_ident
 except ImportError:
-    from thread import get_ident  # Python 2 used thread module instead of _thread
+    try:
+        from _thread import get_ident
+    except ImportError:
+        from thread import get_ident  # Python 2 used thread module instead of _thread
 
-from jdatetime.jalali import \
-    GregorianToJalali, JalaliToGregorian, j_days_in_month
+from jdatetime.jalali import (GregorianToJalali, JalaliToGregorian,
+                              j_days_in_month)
 
 __VERSION__ = "1.9.1"
 MINYEAR = 1

--- a/t/test.py
+++ b/t/test.py
@@ -442,7 +442,7 @@ class TestJdatetimeGetSetLocale(unittest.TestCase):
             record.append(dt.strftime('%B'))
 
         fa_record = []
-        fa_th = threading.Thread(target=record_locale_formatted_date, args=(fa_record, 'fa_IR'))
+        fa_th = threading.Thread(target=record_locale_formatted_date, args=(fa_record, jdatetime.FA_LOCALE))
         fa_th.start()
         fa_th.join()
 
@@ -458,7 +458,7 @@ class TestJdatetimeGetSetLocale(unittest.TestCase):
 
         fa_record = []
         fa_greenlet = greenlet.greenlet(record_locale_formatted_date)
-        fa_greenlet.switch(fa_record, 'fa_IR')
+        fa_greenlet.switch(fa_record, jdatetime.FA_LOCALE)
 
         self.assertEqual([u'یکشنبه', u'خرداد'], fa_record)
 


### PR DESCRIPTION
Add `jdatetime.get_locale` and `jdatetime.set_locale` functions to set the current thread default locale. 
    
Currently new `date`/`datetime` instances pick the default locale from the environment (process or system level locale). However sometimes it's not always easy (or is not desired) to change the process locale, just to have a date instance using a different locale.
    
New module function `set_locale()` allows setting a thread local module level locale value, which is used by `date`/`datetime` instances as the default locale, overriding process/system level locale. This supports both Python threads (from `threading` module in stdlib), and `greenlets` (if available).

This snippet ensures new `date/datetime` instances in current thread use `fa_IR` locale, regardless of the system or process locale settings.
 
```python
import jdatetime
jdatetime.set_locale('fa_IR')
jdatetime.datetime.now().strftime('%A %B')
# u'\u062f\u0648\u0634\u0646\u0628\u0647 \u062e\u0631\u062f\u0627\u062f'
```

This feature can help to solve the problem https://github.com/slashmili/python-jalali/pull/34 tried to solve.
For example in a Django app context, the view can decide the locale, and call `set_locale` before models are loaded, which causes the models to use the desired locale in their `jDateField` attributes. 