### PR TITLE
Added padding-less variations of strftime format symbols

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -523,6 +523,7 @@ class date(object):
                 "%c", self.strftime("%a %b %d %H:%M:%S %Y"))
 
         format = format.replace("%d", '%02.d' % (self.day))
+        format = format.replace("%-d", '%d' % (self.day))
 
         try:
             format = format.replace("%f", '%06.d' % (self.microsecond))
@@ -535,6 +536,11 @@ class date(object):
             format = format.replace("%H", '00')
 
         try:
+            format = format.replace("%-H", '%d' % (self.hour))
+        except:
+            format = format.replace("%-H", '0')
+
+        try:
             if self.hour > 12:
                 format = format.replace("%I", '%02.d' % (self.hour - 12))
             else:
@@ -545,11 +551,17 @@ class date(object):
         format = format.replace("%j", '%03.d' % (self.yday()))
 
         format = format.replace("%m", '%02.d' % (self.month))
+        format = format.replace("%-m", '%d' % (self.month))
 
         try:
             format = format.replace("%M", '%02.d' % (self.minute))
         except:
             format = format.replace("%M", '00')
+        try:
+            format = format.replace("%-M", '%d' % (self.minute))
+        except:
+            format = format.replace("%-M", '0')
+
 
         try:
             if self.hour > 12:
@@ -563,6 +575,11 @@ class date(object):
             format = format.replace("%S", '%02.d' % (self.second))
         except:
             format = format.replace("%S", '00')
+
+        try:
+            format = format.replace("%-S", '%d' % (self.second))
+        except:
+            format = format.replace("%-S", '0')
 
         format = format.replace("%w", str(self.weekday()))
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -557,11 +557,11 @@ class date(object):
             format = format.replace("%M", '%02.d' % (self.minute))
         except:
             format = format.replace("%M", '00')
+
         try:
             format = format.replace("%-M", '%d' % (self.minute))
         except:
             format = format.replace("%-M", '0')
-
 
         try:
             if self.hour > 12:


### PR DESCRIPTION
Based on http://strftime.org/ and the native datetime api strftime should provide `%-m`, `%-d`, `%-H`, `%-M` and `%-S` for decimal values without zero padding.