### PR TITLE
fixed a bug in %p placeholder

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -573,7 +573,7 @@ class date(object):
             format = format.replace("%-M", '0')
 
         try:
-            if self.hour > 12:
+            if self.hour >= 12:
                 format = format.replace("%p", self.j_ampm['PM'])
             else:
                 format = format.replace("%p", self.j_ampm['AM'])

--- a/t/test.py
+++ b/t/test.py
@@ -239,7 +239,7 @@ class TestJDateTime(unittest.TestCase):
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)
         unicode_format = "%a %A %b %B %c %d %H %I %j %m %M %p %S %w %W %x %X %y %Y %f"
-        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 12:13:14 1390 23 12 12 054 02 13 AM 14 6 7 02/23/90 12:12:14 90 1390 000001'
+        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 12:13:14 1390 23 12 12 054 02 13 PM 14 6 7 02/23/90 12:12:14 90 1390 000001'
         self.assertEqual(dt.strftime(unicode_format), output)
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)


### PR DESCRIPTION
When hour == 12, even if minute and second are zero, '%p' format specifier should print 'PM', not 'AM'. Since it's technically 'post meridiem' (past midday). 12 AM is when hour == 0. See https://en.wikipedia.org/wiki/12-hour_clock