### PR TITLE
pretty method added to date and datetime classes

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -147,6 +147,9 @@ class date(object):
                            'Fri']
     j_ampm_en = {'PM': 'PM', 'AM': 'AM'}
 
+    j_today_en = 'today'
+    j_yesterday_en = 'yesterday'
+
     j_months_fa = [u'فروردین',
                    u'اردیبهشت',
                    u'خرداد',
@@ -168,6 +171,9 @@ class date(object):
                      u'پنجشنبه',
                      u'جمعه']
     j_ampm_fa = {'PM': u'بعد از ظهر', 'AM': u'قبل از ظهر'}
+
+    j_today_fa = 'امروز'
+    j_yesterday_fa = 'دیروز'
 
     @property
     def year(self):
@@ -229,12 +235,16 @@ class date(object):
             self.j_weekdays = self.j_weekdays_fa
             self.j_weekdays_short = self.j_weekdays_fa
             self.j_ampm = self.j_ampm_fa
+            self.j_today = self.j_today_fa
+            self.j_yesterday = self.j_yesterday_fa
         else:
             self.j_months = self.j_months_en
             self.j_months_short = self.j_months_short_en
             self.j_weekdays = self.j_weekdays_en
             self.j_weekdays_short = self.j_weekdays_short_en
             self.j_ampm = self.j_ampm_en
+            self.j_today = self.j_today_en
+            self.j_yesterday = self.j_yesterday_en
 
     def _is_fa_locale(self):
         if self.__locale and self.__locale == FA_LOCALE:
@@ -660,9 +670,34 @@ class date(object):
     def aslocale(self, locale):
         return date(self.year, self.month, self.day, locale=locale)
 
+    def pretty(self):
+        today = datetime.today().date()
+
+        if today == self:
+            return self.j_today
+
+        elif today - timedelta(days=1) == self:
+            return self.j_yesterday
+
+        elif today - timedelta(days=today.weekday()) <= self < today:
+            return self.strftime("%A")
+
+        elif today.replace(month=1, day=1) <= self < today:
+            return self.strftime("%d %B")
+
+        else:
+            return self.strftime("%d %B %Y")
+
 
 class datetime(date):
     """datetime(year, month, day, [hour, [minute, [seconds, [microsecond, [tzinfo]]]]]) --> datetime objects"""
+
+    j_just_now_en = 'just now'
+    j_moments_ago_en = 'moments ago'
+
+    j_just_now_fa = 'لحظاتی پیش'
+    j_moments_ago_fa = 'دقایقی پیش'
+
     __time = None
 
     def time(self):
@@ -684,6 +719,14 @@ class datetime(date):
             microsecond=None,
             tzinfo=None, **kwargs):
         date.__init__(self, year, month, day, **kwargs)
+
+        if self._is_fa_locale():
+            self.j_just_now = self.j_just_now_fa
+            self.j_moments_ago = self.j_moments_ago_fa
+        else:
+            self.j_just_now = self.j_just_now_en
+            self.j_moments_ago = self.j_moments_ago_en
+
         tmp_hour = 0
         tmp_min = 0
         tmp_sec = 0
@@ -1254,3 +1297,13 @@ class datetime(date):
     def aslocale(self, locale):
         return datetime(self.year, self.month, self.day, self.hour, self.minute,
                         self.second, self.microsecond, tzinfo=self.tzinfo, locale=locale)
+
+    def pretty(self):
+        now = datetime.now()
+        if now - timedelta(minutes=1) < self <= now:
+            return self.j_just_now
+
+        elif now - timedelta(minutes=5) < self <= now:
+            return self.j_moments_ago
+
+        return "{} {}".format(self.date().pretty(), self.strftime("%H:%M"))


### PR DESCRIPTION
With pretty method you can show user friendly date and times to users. for example if the date is some time at today, your user might not like to see the date "1398/05/09 10:45" but he like to see "today 10:45"

The written code supports bellow strings sorted from most near to most past:

- just now
- a moment ago
- today HH:MM
- yesterday HH:MM
- <weekday name> HH:MM (e.g. Tuesday 18:36) - for dates from the start of the current week until yesterday
- DD <month name> HH:MM (e.g. 1 Mordad 18:36) - for dates older than the current week within the current year
- DD <month name> YYYY HH:MM (e.g. 5 Shahrivar 1397 18:36) - for dates older than the current year and future dates

note that all these strings is also available for Persian if the 'fa_IR' locale is set.

## usage:
usage is easy, just call the pretty() method on any jdatetime.date or jdatetime.datetime objects.