### PR TITLE
Fixes and Improvments

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -29,8 +29,7 @@ MAXYEAR = 9377
 timedelta = py_datetime.timedelta
 tzinfo = py_datetime.tzinfo
 
-timestamp_is_supported = hasattr(py_datetime.datetime, 'timestamp') and \
-                         callable(py_datetime.datetime.timestamp)
+timestamp_is_supported = hasattr(py_datetime.datetime, 'timestamp') and callable(py_datetime.datetime.timestamp)
 
 if sys.version_info[0] >= 3:  # py3
     _int_types = (int,)
@@ -202,9 +201,7 @@ class date(object):
 
     def __init__(self, year, month, day, **kwargs):
         """date(year, month, day) --> date object"""
-        if not (self._check_arg(year) and
-                self._check_arg(month) and
-                self._check_arg(day)):
+        if not (self._check_arg(year) and self._check_arg(month) and self._check_arg(day)):
             raise TypeError("an integer is required" + repr(type(year)))
         if year < MINYEAR or year > MAXYEAR:
             raise ValueError("year is out of range")
@@ -700,8 +697,7 @@ class datetime(date):
         if microsecond is not None:
             tmp_micr = microsecond
 
-        if not (self._check_arg(tmp_hour) and self._check_arg(tmp_min) and
-                self._check_arg(tmp_sec) and self._check_arg(tmp_micr)):
+        if not (self._check_arg(tmp_hour) and self._check_arg(tmp_min) and self._check_arg(tmp_sec) and self._check_arg(tmp_micr)):
             raise TypeError("an integer is required")
 
         self.__time = time(tmp_hour, tmp_min, tmp_sec, tmp_micr, tzinfo)

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -570,7 +570,7 @@ class date(object):
                 format = format.replace("%I", '%02.d' % (12))
         except:
             format = format.replace("%I", '12')
-         
+
         try:
             if self.hour > 12:
                 format = format.replace("%-I", '%02.d' % (self.hour - 12))

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -622,7 +622,7 @@ class date(object):
             format = format.replace("%x", self.strftime("%m/%d/%y"))
 
         if '%X' in format:
-            format = format.replace("%X", self.strftime('%H:%I:%S'))
+            format = format.replace("%X", self.strftime('%H:%M:%S'))
 
         format = format.replace("%Y", str(self.year))
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -500,7 +500,7 @@ class date(object):
 
     def weeknumber(self):
         """Return week number """
-        return (self.day + date(self.year, 1, 1).weekday() - 1) // 7 + 1
+        return (self.yday() + date(self.year, 1, 1).weekday() - 1) // 7 + 1
 
     def isocalendar(self):
         """Return a 3-tuple, (ISO year, ISO week number, ISO weekday)."""

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -564,10 +564,22 @@ class date(object):
         try:
             if self.hour > 12:
                 format = format.replace("%I", '%02.d' % (self.hour - 12))
-            else:
+            elif self.hour > 0:
                 format = format.replace("%I", '%02.d' % (self.hour))
+            else:
+                format = format.replace("%I", '%02.d' % (12))
         except:
-            format = format.replace("%I", '00')
+            format = format.replace("%I", '12')
+         
+        try:
+            if self.hour > 12:
+                format = format.replace("%-I", '%02.d' % (self.hour - 12))
+            elif self.hour > 0:
+                format = format.replace("%-I", '%02.d' % (self.hour))
+            else:
+                format = format.replace("%-I", '%02.d' % (12))
+        except:
+            format = format.replace("%-I", '12')
 
         format = format.replace("%j", '%03.d' % (self.yday()))
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -492,20 +492,7 @@ class date(object):
         """Return the day of the week represented by the date.
         Shanbeh == 0 ... Jomeh == 6"""
         gd = self.togregorian()
-        if gd.weekday() == 5:
-            return 0
-        if gd.weekday() == 6:
-            return 1
-        if gd.weekday() == 0:
-            return 2
-        if gd.weekday() == 1:
-            return 3
-        if gd.weekday() == 2:
-            return 4
-        if gd.weekday() == 3:
-            return 5
-        if gd.weekday() == 4:
-            return 6
+        return (gd.weekday()-5) % 7
 
     def isoweekday(self):
         """Return the day of the week as an integer, where Shanbeh is 1 and Jomeh is 7"""

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -29,7 +29,9 @@ MAXYEAR = 9377
 timedelta = py_datetime.timedelta
 tzinfo = py_datetime.tzinfo
 
-timestamp_is_supported = hasattr(py_datetime.datetime, 'timestamp') and callable(py_datetime.datetime.timestamp)
+timestamp_is_supported = hasattr(py_datetime.datetime, 'timestamp') and\
+    callable(py_datetime.datetime.timestamp)
+
 
 if sys.version_info[0] >= 3:  # py3
     _int_types = (int,)
@@ -105,6 +107,7 @@ def get_locale():
 
 
 class date(object):
+
     """date(year, month, day) --> date object"""
     j_months_en = ['Farvardin',
                    'Ordibehesht',
@@ -370,7 +373,8 @@ class date(object):
         if isinstance(other, py_datetime.date):
             return other - self.togregorian()
         raise TypeError("unsupported operand type for -: '%s' and '%s'" %
-                        (type(other), type(self)))
+                            (type(other), type(self)))
+
 
     def __eq__(self, other_date):
         """x.__eq__(y) <==> x==y"""
@@ -697,7 +701,8 @@ class datetime(date):
         if microsecond is not None:
             tmp_micr = microsecond
 
-        if not (self._check_arg(tmp_hour) and self._check_arg(tmp_min) and self._check_arg(tmp_sec) and self._check_arg(tmp_micr)):
+        if not (self._check_arg(tmp_hour) and self._check_arg(tmp_min) and
+                self._check_arg(tmp_sec) and self._check_arg(tmp_micr)):
             raise TypeError("an integer is required")
 
         self.__time = time(tmp_hour, tmp_min, tmp_sec, tmp_micr, tzinfo)
@@ -1020,7 +1025,7 @@ class datetime(date):
         if isinstance(other, py_datetime.datetime):
             return other - self.togregorian()
         raise TypeError("unsupported operand type for -: '%s' and '%s'" %
-                        (type(other), type(self)))
+                            (type(other), type(self)))
 
     def __eq__(self, other_datetime):
         """x.__eq__(y) <==> x==y"""

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -29,9 +29,8 @@ MAXYEAR = 9377
 timedelta = py_datetime.timedelta
 tzinfo = py_datetime.tzinfo
 
-timestamp_is_supported = hasattr(py_datetime.datetime, 'timestamp') and\
-    callable(py_datetime.datetime.timestamp)
-
+timestamp_is_supported = hasattr(py_datetime.datetime, 'timestamp') and \
+                         callable(py_datetime.datetime.timestamp)
 
 if sys.version_info[0] >= 3:  # py3
     _int_types = (int,)
@@ -107,7 +106,6 @@ def get_locale():
 
 
 class date(object):
-
     """date(year, month, day) --> date object"""
     j_months_en = ['Farvardin',
                    'Ordibehesht',
@@ -375,8 +373,7 @@ class date(object):
         if isinstance(other, py_datetime.date):
             return other - self.togregorian()
         raise TypeError("unsupported operand type for -: '%s' and '%s'" %
-                            (type(other), type(self)))
-
+                        (type(other), type(self)))
 
     def __eq__(self, other_date):
         """x.__eq__(y) <==> x==y"""
@@ -1027,7 +1024,7 @@ class datetime(date):
         if isinstance(other, py_datetime.datetime):
             return other - self.togregorian()
         raise TypeError("unsupported operand type for -: '%s' and '%s'" %
-                            (type(other), type(self)))
+                        (type(other), type(self)))
 
     def __eq__(self, other_datetime):
         """x.__eq__(y) <==> x==y"""

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -562,22 +562,12 @@ class date(object):
             format = format.replace("%-H", '0')
 
         try:
-            if self.hour > 12:
-                format = format.replace("%I", '%02.d' % (self.hour - 12))
-            elif self.hour > 0:
-                format = format.replace("%I", '%02.d' % (self.hour))
-            else:
-                format = format.replace("%I", '%02.d' % (12))
+            format = format.replace("%I", '%02.d' % (self.hour % 12 or 12))
         except:
             format = format.replace("%I", '12')
 
         try:
-            if self.hour > 12:
-                format = format.replace("%-I", '%02.d' % (self.hour - 12))
-            elif self.hour > 0:
-                format = format.replace("%-I", '%02.d' % (self.hour))
-            else:
-                format = format.replace("%-I", '%02.d' % (12))
+            format = format.replace("%-I", '%d' % (self.hour % 12 or 12))
         except:
             format = format.replace("%-I", '12')
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -204,7 +204,9 @@ class date(object):
 
     def __init__(self, year, month, day, **kwargs):
         """date(year, month, day) --> date object"""
-        if not (self._check_arg(year) and self._check_arg(month) and self._check_arg(day)):
+        if not (self._check_arg(year) and
+                self._check_arg(month) and
+                self._check_arg(day)):
             raise TypeError("an integer is required" + repr(type(year)))
         if year < MINYEAR or year > MAXYEAR:
             raise ValueError("year is out of range")

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -492,7 +492,7 @@ class date(object):
         """Return the day of the week represented by the date.
         Shanbeh == 0 ... Jomeh == 6"""
         gd = self.togregorian()
-        return (gd.weekday()-5) % 7
+        return (gd.weekday() - 5) % 7
 
     def isoweekday(self):
         """Return the day of the week as an integer, where Shanbeh is 1 and Jomeh is 7"""
@@ -500,7 +500,7 @@ class date(object):
 
     def weeknumber(self):
         """Return week number """
-        return self.yday() // 7
+        return (self.day + date(self.year, 1, 1).weekday() - 1) // 7 + 1
 
     def isocalendar(self):
         """Return a 3-tuple, (ISO year, ISO week number, ISO weekday)."""

--- a/t/test.py
+++ b/t/test.py
@@ -251,7 +251,7 @@ class TestJDateTime(unittest.TestCase):
     def test_strftime(self):
         s = jdatetime.date(1390, 2, 23)
         string_format = "%a %A %b %B %c %d %H %I %j %m %M %p %S %w %W %x %X %y %Y %f %z %Z"
-        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 00:00:00 1390 23 00 00 054 02 00 AM 00 6 8 02/23/90 00:00:00 90 1390 000000  '
+        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 00:00:00 1390 23 00 12 054 02 00 AM 00 6 8 02/23/90 00:00:00 90 1390 000000  '
         self.assertEqual(s.strftime(string_format), output)
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)

--- a/t/test.py
+++ b/t/test.py
@@ -126,6 +126,11 @@ class TestJDate(unittest.TestCase):
         self.assertEqual(new_date.month, 4)
         self.assertEqual(new_date.day, 21)
         self.assertEqual(new_date.locale, 'nl_NL')
+    
+    def test_subtract_datetime_date(self):
+        date = jdatetime.date(1397, 4, 22, locale='nl_NL')
+        delta = date - datetime.date(2018, 7, 13)
+        self.assertEqual(delta.days, 1)
 
     def test_subtract_datetime_date(self):
         date = jdatetime.date(1397, 4, 22, locale='nl_NL')

--- a/t/test.py
+++ b/t/test.py
@@ -251,12 +251,12 @@ class TestJDateTime(unittest.TestCase):
     def test_strftime(self):
         s = jdatetime.date(1390, 2, 23)
         string_format = "%a %A %b %B %c %d %H %I %j %m %M %p %S %w %W %x %X %y %Y %f %z %Z"
-        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 00:00:00 1390 23 00 00 054 02 00 AM 00 6 7 02/23/90 00:00:00 90 1390 000000  '
+        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 00:00:00 1390 23 00 00 054 02 00 AM 00 6 8 02/23/90 00:00:00 90 1390 000000  '
         self.assertEqual(s.strftime(string_format), output)
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)
         unicode_format = "%a %A %b %B %c %d %H %I %j %m %M %p %S %w %W %x %X %y %Y %f"
-        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 12:13:14 1390 23 12 12 054 02 13 PM 14 6 7 02/23/90 12:12:14 90 1390 000001'
+        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 12:13:14 1390 23 12 12 054 02 13 PM 14 6 8 02/23/90 12:12:14 90 1390 000001'
         self.assertEqual(dt.strftime(unicode_format), output)
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)

--- a/t/test.py
+++ b/t/test.py
@@ -256,7 +256,7 @@ class TestJDateTime(unittest.TestCase):
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)
         unicode_format = "%a %A %b %B %c %d %H %I %j %m %M %p %S %w %W %x %X %y %Y %f"
-        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 12:13:14 1390 23 12 12 054 02 13 PM 14 6 8 02/23/90 12:12:14 90 1390 000001'
+        output = 'Fri Friday Ord Ordibehesht Fri Ord 23 12:13:14 1390 23 12 12 054 02 13 PM 14 6 8 02/23/90 12:13:14 90 1390 000001'
         self.assertEqual(dt.strftime(unicode_format), output)
 
         dt = jdatetime.datetime(1390, 2, 23, 12, 13, 14, 1)

--- a/t/test.py
+++ b/t/test.py
@@ -129,7 +129,7 @@ class TestJDate(unittest.TestCase):
     
     def test_subtract_datetime_date(self):
         date = jdatetime.date(1397, 4, 22, locale='nl_NL')
-        delta = date - datetime.date(2018, 7, 13)
+        delta = date - datetime.date(2018, 7, 12)
         self.assertEqual(delta.days, 1)
 
     def test_subtract_datetime_date(self):

--- a/t/test.py
+++ b/t/test.py
@@ -144,6 +144,11 @@ class TestJDate(unittest.TestCase):
             time.struct_time((2018, 7, 13, 0, 0, 0, 4, 194, -1)),
         )
 
+    def test_all_weekdays(self):
+        date = jdatetime.date(1394, 1, 1)  # it is saturday
+        for i in range(7):  # test th whole week
+            self.assertEqual((date + datetime.timedelta(days=i)).weekday(), i)
+
 
 class TestJDateTime(unittest.TestCase):
     def test_datetime_date_method_keeps_datetime_locale_on_date_instance(self):


### PR DESCRIPTION
- Fixes '12:mm:ss am' display problem in strftime 
  - In 12 hour time, there is no hour 00, day begins with 12:00am after midnight.
- Adds support for '%-I' format token which were missed before
- Fixes '%X' token in strftime:
  - it should return 'HH:MM:SS' format but it returns 'HH:II:SS'!
- Fixes  Week of year, currently it starts with zero and increases every 7 days, ignoring weekdays
   - In Jalali Calendar, The first week of year is the week containing 1st of Farvardin and this week can be less than 7 days. So calculating week of year by dividing day-of-year by 7 was incorrect. For example, if 1st of Farvardin is Thursday, 3rd of Farvardin is Saturday and should be in week 2, but the code shows week 0. Well another point is that in Jalali calendar (and any other calendar that I have seen) week numbers start at 1 not 0.

- Refactor: `weekday` was rewritten to avoid having  lot's of `if` cases.