### PR TITLE
Handle date input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ python:
     - "2.6"
     - "2.7"
     - "3.2"
-    - "3.3"
     - "3.4"
+    - "3.5"
+    - "3.6"
+    - "nightly"
 before_script:
   - "pep8 --ignore=E501  jdatetime/__init__.py"
   - sudo locale-gen fa_IR
@@ -15,3 +17,4 @@ matrix:
     allow_failures:
         - python: "3.2"
         - python: "2.6"
+        - python: "nightly"

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -279,12 +279,15 @@ class date(object):
         jdatetime.date.fromgregorian(date=datetime.date, locale='fa_IR')
         """
         locale = kw.get('locale')
-        if 'date' in kw and isinstance(kw['date'], py_datetime.date):
+        if 'date' in kw:
             d = kw['date']
-            (y, m, d) = GregorianToJalali(d.year,
-                                          d.month,
-                                          d.day).getJalaliList()
-            return date(y, m, d, locale=locale)
+            try:
+                (y, m, d) = GregorianToJalali(d.year,
+                                              d.month,
+                                              d.day).getJalaliList()
+                return date(y, m, d, locale=locale)
+            except AttributeError:
+                raise ValueError('When calling fromgregorian(date=) the parameter should be a date like object.')
         if 'day' in kw and 'month' in kw and 'year' in kw:
             (year, month, day) = (kw['year'], kw['month'], kw['day'])
             (y, m, d) = GregorianToJalali(year, month, day).getJalaliList()
@@ -1113,35 +1116,38 @@ class datetime(date):
         return not self.__eq__(other_datetime)
 
     @staticmethod
-    def fromgregorian(**kw):
-        """Convert gregorian to jalali and return jdatetime.datetime
-        jdatetime.date.fromgregorian(day=X,month=X,year=X,[hour=X, [minute=X, [second=X, [tzinfo=X]]]])
-        jdatetime.date.fromgregorian(date=datetime.date)
-        jdatetime.date.fromgregorian(datetime=datetime.datetime)
-        jdatetime.date.fromgregorian(datetime=datetime.datetime, locale='fa_IR')
+        def fromgregorian(**kw):
+        """Convert gregorian to jalali and return jadatetime.datetime
+        jadatetime.date.fromgregorian(day=X,month=X,year=X,[hour=X, [minute=X, [second=X, [tzinfo=X]]]])
+        jadatetime.date.fromgregorian(date=datetime.date)
+        jadatetime.date.fromgregorian(datetime=datetime.date)
+        jadatetime.date.fromgregorian(datetime=datetime.datetime)
+        jadatetime.date.fromgregorian(datetime=datetime.datetime, locale='fa_IR')
         """
         locale = kw.get('locale')
-        if 'date' in kw and isinstance(kw['date'], py_datetime.date):
-            d = kw['date']
-            (y, m, d) = GregorianToJalali(d.year,
-                                          d.month,
-                                          d.day).getJalaliList()
-            return datetime(y, m, d, locale=locale)
-        if 'datetime' in kw and isinstance(
-                kw['datetime'], py_datetime.datetime):
-            dt = kw['datetime']
-            (y, m, d) = GregorianToJalali(
-                dt.year, dt.month, dt.day).getJalaliList()
-            return datetime(
-                y,
-                m,
-                d,
-                dt.hour,
-                dt.minute,
-                dt.second,
-                dt.microsecond,
-                dt.tzinfo,
-                locale=locale)
+        date_param = kw.get('date') or kw.get('datetime')
+        if date_param:
+            try:
+                (y, m, d) = GregorianToJalali(date_param.year,
+                                              date_param.month,
+                                              date_param.day).getJalaliList()
+            except AttributeError:
+                raise ValueError(
+                    'When calling fromgregorian(date=) or fromgregorian(datetime=) the parameter should be date like.')
+            try:
+                return datetime(
+                    y,
+                    m,
+                    d,
+                    date_param.hour,
+                    date_param.minute,
+                    date_param.second,
+                    date_param.microsecond,
+                    date_param.tzinfo,
+                    locale=locale)
+            except AttributeError:
+                return datetime(y, m, d, locale=locale)
+
         if 'day' in kw and 'month' in kw and 'year' in kw:
             (year, month, day) = (kw['year'], kw['month'], kw['day'])
             (y, m, d) = GregorianToJalali(year, month, day).getJalaliList()

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -1116,7 +1116,7 @@ class datetime(date):
         return not self.__eq__(other_datetime)
 
     @staticmethod
-        def fromgregorian(**kw):
+    def fromgregorian(**kw):
         """Convert gregorian to jalali and return jadatetime.datetime
         jadatetime.date.fromgregorian(day=X,month=X,year=X,[hour=X, [minute=X, [second=X, [tzinfo=X]]]])
         jadatetime.date.fromgregorian(date=datetime.date)

--- a/t/test.py
+++ b/t/test.py
@@ -226,17 +226,17 @@ class TestJDateTime(unittest.TestCase):
     def test_date_conversion_date_input(self):
         # todo: add some corner cases
         d1 = datetime.date(2010, 11, 23)
-        jd1 = jadatetime.date(1389, 9, 2)
+        jd1 = jdatetime.date(1389, 9, 2)
         d2 = datetime.date(2011, 5, 13)
-        jd2 = jadatetime.date(1390, 2, 23)
+        jd2 = jdatetime.date(1390, 2, 23)
 
         self.assertEqual(d1, jd1.togregorian())
         self.assertEqual(d2, jd2.togregorian())
-        self.assertEqual(jd1, jadatetime.date.fromgregorian(date=d1))
-        self.assertEqual(jd2, jadatetime.date.fromgregorian(date=d2))
+        self.assertEqual(jd1, jdatetime.date.fromgregorian(date=d1))
+        self.assertEqual(jd2, jdatetime.date.fromgregorian(date=d2))
 
     def test_date_conversion_integer_input(self):
-        d_check_with = jadatetime.date(1390, 2, 23)
+        d_check_with = jdatetime.date(1390, 2, 23)
 
     
         jd_datetime = jdatetime.datetime.fromgregorian(year=2011,
@@ -450,7 +450,7 @@ class TestJDateTime(unittest.TestCase):
      
     def test_fromgregorian_accepts_named_argument_of_date_with_date_input(self):
         gdt = datetime.date(2018, 7, 15)
-        jdt = jadatetime.datetime.fromgregorian(date=gdt, locale='nl_NL')
+        jdt = jdatetime.datetime.fromgregorian(date=gdt, locale='nl_NL')
         self.assertEqual(jdt.year, 1397)
         self.assertEqual(jdt.month, 4)
         self.assertEqual(jdt.day, 24)
@@ -460,7 +460,7 @@ class TestJDateTime(unittest.TestCase):
 
     def test_fromgregorian_accepts_named_argument_of_date_with_datetime_input(self):
         gdt = datetime.datetime(2018, 7, 15, 11, 7, 0)
-        jdt = jadatetime.datetime.fromgregorian(date=gdt, locale='nl_NL')
+        jdt = jdatetime.datetime.fromgregorian(date=gdt, locale='nl_NL')
         self.assertEqual(jdt.year, 1397)
         self.assertEqual(jdt.month, 4)
         self.assertEqual(jdt.day, 24)

--- a/t/test.py
+++ b/t/test.py
@@ -223,21 +223,22 @@ class TestJDateTime(unittest.TestCase):
         self.assertEqual(True, dtg - jdatetime.timedelta(seconds=1) < dtg)
         self.assertEqual(False, dtg is None)
 
-    def test_dateconversion(self):
-        sample = jdatetime.date(1389, 9, 2)
+    def test_date_conversion_date_input(self):
+        # todo: add some corner cases
+        d1 = datetime.date(2010, 11, 23)
+        jd1 = jadatetime.date(1389, 9, 2)
+        d2 = datetime.date(2011, 5, 13)
+        jd2 = jadatetime.date(1390, 2, 23)
 
-        d_check_with = jdatetime.date(1390, 2, 23)
-        #TEST date
-        self.assertEqual(True, sample.togregorian() ==
-                         datetime.date(2010, 11, 23))
-        self.assertEqual(True, jdatetime.date.fromgregorian(
-                         date=datetime.date(2011, 5, 13)) == d_check_with)
+        self.assertEqual(d1, jd1.togregorian())
+        self.assertEqual(d2, jd2.togregorian())
+        self.assertEqual(jd1, jadatetime.date.fromgregorian(date=d1))
+        self.assertEqual(jd2, jadatetime.date.fromgregorian(date=d2))
 
-        #TEST datetime
-        self.assertEqual(True, jdatetime.datetime.fromgregorian(
-                         datetime=datetime.datetime(2011, 5, 13)).date() ==
-                         d_check_with)
+    def test_date_conversion_integer_input(self):
+        d_check_with = jadatetime.date(1390, 2, 23)
 
+    
         jd_datetime = jdatetime.datetime.fromgregorian(year=2011,
                                                        month=5,
                                                        day=13,
@@ -446,6 +447,27 @@ class TestJDateTime(unittest.TestCase):
         self.assertEqual(jdt.hour, 11)
         self.assertEqual(jdt.minute, 7)
         self.assertEqual(jdt.locale, 'nl_NL')
+     
+    def test_fromgregorian_accepts_named_argument_of_date_with_date_input(self):
+        gdt = datetime.date(2018, 7, 15)
+        jdt = jadatetime.datetime.fromgregorian(date=gdt, locale='nl_NL')
+        self.assertEqual(jdt.year, 1397)
+        self.assertEqual(jdt.month, 4)
+        self.assertEqual(jdt.day, 24)
+        self.assertEqual(jdt.hour, 0)
+        self.assertEqual(jdt.minute, 0)
+        self.assertEqual(jdt.locale, 'nl_NL')
+
+    def test_fromgregorian_accepts_named_argument_of_date_with_datetime_input(self):
+        gdt = datetime.datetime(2018, 7, 15, 11, 7, 0)
+        jdt = jadatetime.datetime.fromgregorian(date=gdt, locale='nl_NL')
+        self.assertEqual(jdt.year, 1397)
+        self.assertEqual(jdt.month, 4)
+        self.assertEqual(jdt.day, 24)
+        self.assertEqual(jdt.hour, 11)
+        self.assertEqual(jdt.minute, 7)
+        self.assertEqual(jdt.locale, 'nl_NL')
+
 
     def test_fromgregorian_accepts_year_month_day_and_locale(self):
         jdt = jdatetime.datetime.fromgregorian(year=2018, month=7, day=15, locale='nl_NL')


### PR DESCRIPTION
based on #57

> jdatetime.datetime.fromgregorian(datetime=datetime.date.today()) raises an error. But it would be nicer if it doesn't and behave like date= argument.

