### PR TITLE
Fixed %Y length in strptime

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -896,7 +896,7 @@ class datetime(date):
             '%m': ['[0-9]{1,2}', 'month'],
             '%M': ['[0-9]{1,2}', 'minute'],
             '%S': ['[0-9]{1,2}', 'second'],
-            '%Y': ['[0-9]{4,5}', 'year'],
+            '%Y': ['[0-9]{4}', 'year'],
         }
         regex = format
         find = _re.compile("(%[a-zA-Z])")

--- a/t/test.py
+++ b/t/test.py
@@ -373,6 +373,14 @@ class TestJDateTime(unittest.TestCase):
         dt2 = jdatetime.datetime(1363, 6, 6, 12, 13, 14)
 
         self.assertEqual(True, dt1 == dt2)
+    
+    def test_strptime_bare(self):
+        date_string = "13630606121314"
+        date_format = "%Y%m%d%H%M%S"
+        dt1 = jdatetime.datetime.strptime(date_string, date_format)
+        dt2 = jdatetime.datetime(1363, 6, 6, 12, 13, 14)
+
+        self.assertEqual(True, dt1 == dt2)
 
     def test_strptime_handles_alphabets_in_format(self):
         date_string = "1363-6-6T12:13:14"

--- a/t/test.py
+++ b/t/test.py
@@ -380,7 +380,7 @@ class TestJDateTime(unittest.TestCase):
         dt1 = jdatetime.datetime.strptime(date_string, date_format)
         dt2 = jdatetime.datetime(1363, 6, 6, 12, 13, 14)
 
-        self.assertEqual(True, dt1 == dt2)
+        self.assertTrue(dt1 == dt2)
 
     def test_strptime_handles_alphabets_in_format(self):
         date_string = "1363-6-6T12:13:14"


### PR DESCRIPTION
Check this line in your version:
```py
jdatetime.datetime.strptime('13980101000000', '%Y%m%d%H%M%S')
```