### PR TITLE
Add support for python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
     - "nightly"
 before_script:
   - "pep8 --ignore=E501  jdatetime/__init__.py"

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -625,7 +625,10 @@ class date(object):
 
         try:
             sign = "+"
-            diff = self.tzinfo.utcoffset(self)
+            try:
+                diff = self.tzinfo.utcoffset(self)
+            except TypeError:
+                diff = self.tzinfo.utcoffset(None)
             diff_sec = diff.seconds
             if diff.days > 0 or diff.days < -1:
                 raise ValueError(
@@ -644,6 +647,8 @@ class date(object):
 
         try:
             format = format.replace("%Z", self.tzinfo.tzname(self))
+        except TypeError:
+            format = format.replace("%Z", self.tzinfo.tzname(None))
         except AttributeError:
             format = format.replace("%Z", '')
 


### PR DESCRIPTION
- Added python3.7 and 3.8 support.
- Small change to handle django2.2 datetime objects.

from django2.2 `django.utils.timezone.FixedOffset is deprecated in favor of datetime.timezone.`

I got this error with python3.7 and django2.2 when I tried to save an object in admin panel
```  
File "/home/hasan/work/python-jalali/jdatetime/__init__.py", line 628, in strftime
    diff = self.tzinfo.utcoffset(self)
TypeError: utcoffset(dt) argument must be a datetime instance or None, not datetime
```

this patch fixes the problem.
I am going to create another patch for django-jalali and make it compatible for django2.2. that needs to merge this one first

