### PR TITLE
Define jdatetime.date.min and max outside the date class definition

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,3 @@
-jdatetime/__init__.py:    #TODO fixed errror :  name 'date' is not defined
 jdatetime/__init__.py:    #TODO: create jtime !
 jdatetime/__init__.py:        #TODO: change stupid str.replace 
 jdatetime/__init__.py:    #TODO: check what this def does !

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -666,6 +666,7 @@ class date(object):
     def aslocale(self, locale):
         return date(self.year, self.month, self.day, locale=locale)
 
+
 """The earliest representable date, date(MINYEAR, 1, 1)"""
 date.min = date(MINYEAR, 1, 1)
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -264,13 +264,6 @@ class date(object):
     non-equal date objects, timedelta(days=1)."""
     resolution = timedelta(1)
 
-    """The earliest representable date, date(MINYEAR, 1, 1)"""
-    # min = date(MINYEAR, 1, 1)
-    # TODO fixed errror:  name 'date' is not defined
-    """The latest representable date, date(MAXYEAR, 12, 31)."""
-
-    # max = date(MAXYEAR, 12,29)
-
     def isleap(self):
         """check if year is leap year
             algortim is based on http://en.wikipedia.org/wiki/Leap_year"""
@@ -672,6 +665,12 @@ class date(object):
 
     def aslocale(self, locale):
         return date(self.year, self.month, self.day, locale=locale)
+
+"""The earliest representable date, date(MINYEAR, 1, 1)"""
+date.min = date(MINYEAR, 1, 1)
+
+"""The latest representable date, date(MAXYEAR, 12, 31)."""
+date.max = date(MAXYEAR, 12,29)
 
 
 class datetime(date):

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -670,7 +670,7 @@ class date(object):
 date.min = date(MINYEAR, 1, 1)
 
 """The latest representable date, date(MAXYEAR, 12, 31)."""
-date.max = date(MAXYEAR, 12,29)
+date.max = date(MAXYEAR, 12, 30)
 
 
 class datetime(date):

--- a/t/test.py
+++ b/t/test.py
@@ -160,6 +160,7 @@ class TestJDate(unittest.TestCase):
         with self.assertRaises(ValueError, msg="Should raise an exception when we ge below date.min"):
             _ = dmin - jdatetime.date.resolution
 
+
 class TestJDateTime(unittest.TestCase):
     def test_datetime_date_method_keeps_datetime_locale_on_date_instance(self):
         datetime = jdatetime.datetime(1397, 4, 22, locale='nl_NL')

--- a/t/test.py
+++ b/t/test.py
@@ -144,6 +144,21 @@ class TestJDate(unittest.TestCase):
         for i in range(7):  # test th whole week
             self.assertEqual((date + datetime.timedelta(days=i)).weekday(), i)
 
+    def test_max_year(self):
+        dmax = jdatetime.date.max
+        self.assertTrue(isinstance(dmax, jdatetime.date))
+        self.assertEqual(dmax.year, jdatetime.MAXYEAR)
+        self.assertRaises(ValueError, jdatetime.date, jdatetime.MAXYEAR + 1, 1, 1)
+        with self.assertRaises(ValueError, msg="Should raise an exception when we go over date.max"):
+            _ = dmax + jdatetime.date.resolution
+
+    def test_min_year(self):
+        dmin = jdatetime.date.min
+        self.assertTrue(isinstance(dmin, jdatetime.date))
+        self.assertEqual(dmin.year, jdatetime.MINYEAR)
+        self.assertRaises(ValueError, jdatetime.date, jdatetime.MINYEAR - 1, 1, 1)
+        with self.assertRaises(ValueError, msg="Should raise an exception when we ge below date.min"):
+            _ = dmin - jdatetime.date.resolution
 
 class TestJDateTime(unittest.TestCase):
     def test_datetime_date_method_keeps_datetime_locale_on_date_instance(self):


### PR DESCRIPTION
This is how datetime.date.min and max are defined in cpython implementation