### PR TITLE
Add ZoneInfo support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Add
+* Add ZoneInfo support
+
 ## [3.6.4] - 2021-09-15
 ### Add
 * Add date.min based on cpython implementation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,5 +13,8 @@ environment:
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
+install:
+  - py -m pip install tzdata
+
 test_script:
-  - "%PYTHON%\\python.exe t/test.py"
+  - py t/test.py

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -635,10 +635,7 @@ class date(object):
 
         try:
             sign = "+"
-            try:
-                diff = self.tzinfo.utcoffset(self)
-            except TypeError:
-                diff = self.tzinfo.utcoffset(None)
+            diff = self.utcoffset()
             diff_sec = diff.seconds
             if diff.days > 0 or diff.days < -1:
                 raise ValueError(
@@ -654,11 +651,9 @@ class date(object):
         except AttributeError:
             format = format.replace("%z", '')
 
-        try:
-            format = format.replace("%Z", self.tzinfo.tzname(self))
-        except TypeError:
-            format = format.replace("%Z", self.tzinfo.tzname(None))
-        except AttributeError:
+        if hasattr(self, 'tzname') and self.tzname() is not None:
+            format = format.replace("%Z", self.tzname())
+        else:
             format = format.replace("%Z", '')
 
         return format
@@ -1294,13 +1289,13 @@ class datetime(date):
     def tzname(self):
         """Return self.tzinfo.tzname(self)"""
         if self.tzinfo:
-            return self.tzinfo.tzname(self)
+            return self.tzinfo.tzname(self.togregorian())
         return None
 
     def utcoffset(self):
         """Return self.tzinfo.utcoffset(self)."""
         if self.tzinfo:
-            return self.tzinfo.utcoffset(self)
+            return self.tzinfo.utcoffset(self.togregorian())
 
     def utctimetuple(self):
         """Return UTC time tuple, compatible with time.localtime().
@@ -1310,11 +1305,10 @@ class datetime(date):
         return dt.utctimetuple()
 
     def __str__(self):
-        mil = self.strftime("%f")
-        if int(mil) == 0:
+        if self.microsecond == 0:
             mil = ""
         else:
-            mil = "." + mil
+            mil = "." + str(self.microsecond)
         tz = self.strftime("%z")
         return self.strftime("%Y-%m-%d %H:%M:%S") + "%s%s" % (mil, tz)
 

--- a/t/test.py
+++ b/t/test.py
@@ -14,6 +14,12 @@ try:
 except ImportError:
     greenlet_installed = False
 
+try:
+    import zoneinfo
+except ImportError:
+    zoneinfo = None
+
+
 BASEDIR = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")
 )
@@ -697,6 +703,12 @@ class TestJDateTime(unittest.TestCase):
         self.assertEqual(seconds, '1398-04-11T11:06:05')
         self.assertEqual(milliseconds, '1398-04-11T11:06:05.123')
         self.assertEqual(microseconds, '1398-04-11T11:06:05.123456')
+
+    @unittest.skipIf(zoneinfo is None, "ZoneInfo not supported!")
+    def test_zoneinfo_as_timezone(self):
+        tzinfo = zoneinfo.ZoneInfo('Asia/Tehran')
+        jdt = jdatetime.datetime(1398, 4, 11, 11, 6, 5, 123456, tzinfo=tzinfo)
+        self.assertEqual(str(jdt), '1398-04-11 11:06:05.123456+0430')
 
 
 class TestJdatetimeGetSetLocale(unittest.TestCase):


### PR DESCRIPTION
[The Python standard library’s zoneinfo is now the default timezone implementation in Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#zoneinfo-default-timezone-implementation).
We need this change to make [django-jalali](https://github.com/slashmili/django-jalali) compatible with Django 4.0