### PR TITLE
Add support for jalali months in persian alphabets in strftime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.7.1] - 2021-12-21
+## Unreleased
 * Add support for jalali months in persian alphabets
 
 ## [3.7.0] - 2021-12-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.7.1] - 2021-12-21
+* Add support for jalali months in persian alphabets
+
 ## [3.7.0] - 2021-12-20
 ### Add
 * Add ZoneInfo support

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -553,6 +553,8 @@ class date(object):
 
         format = format.replace("%B", self.j_months[self.month - 1])
 
+        format = format.replace("%e", self.j_months_fa[self.month - 1])
+
         if '%c' in format:
             format = format.replace("%c", self.strftime("%a %b %d %H:%M:%S %Y"))
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -553,7 +553,7 @@ class date(object):
 
         format = format.replace("%B", self.j_months[self.month - 1])
 
-        format = format.replace("%e", self.j_months_fa[self.month - 1])
+        format = format.replace("%E", self.j_months_fa[self.month - 1])
 
         if '%c' in format:
             format = format.replace("%c", self.strftime("%a %b %d %H:%M:%S %Y"))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
     name='jdatetime',
-    version='3.7.0',
+    version='3.7.1',
     packages=['jdatetime', ],
     license='Python Software Foundation License',
     keywords='Jalali implementation of Python datetime',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
     name='jdatetime',
-    version='3.7.1',
+    version='3.7.0',
     packages=['jdatetime', ],
     license='Python Software Foundation License',
     keywords='Jalali implementation of Python datetime',

--- a/t/test.py
+++ b/t/test.py
@@ -90,12 +90,11 @@ class TestJDate(unittest.TestCase):
         self.assertEqual(date.strftime('%A'), u'شنبه')
 
     def test_strftime_fa_month(self):
-        j_months_fa = jdatetime.date.j_months_fa
-        month = 0
-        for date in range(12):
-            month += 1
-            j_month_fa = jdatetime.date(year=1400, month=month, day=10).strftime("%E")
-            self.assertEqual(j_month_fa, j_months_fa[month - 1])
+        for month in range(1, 13):
+            self.assertEqual(
+                jdatetime.date(year=1400, month=month, day=10).strftime("%E"),
+                jdatetime.date.j_months_fa[month - 1],
+            )
 
     def test_dates_are_not_equal_if_locales_are_different(self):
         date_fa = jdatetime.date(1397, 4, 22, locale='fa_IR')

--- a/t/test.py
+++ b/t/test.py
@@ -94,7 +94,7 @@ class TestJDate(unittest.TestCase):
         month = 0
         for date in range(12):
             month += 1
-            j_month_fa = jdatetime.date(year=1400, month=month, day=10).strftime("%e")
+            j_month_fa = jdatetime.date(year=1400, month=month, day=10).strftime("%E")
             self.assertEqual(j_month_fa, j_months_fa[month - 1])
 
     def test_dates_are_not_equal_if_locales_are_different(self):

--- a/t/test.py
+++ b/t/test.py
@@ -89,6 +89,14 @@ class TestJDate(unittest.TestCase):
         date = jdatetime.date(1397, 4, 23, locale=jdatetime.FA_LOCALE)
         self.assertEqual(date.strftime('%A'), u'شنبه')
 
+    def test_strftime_fa_month(self):
+        j_months_fa = jdatetime.date.j_months_fa
+        month = 0
+        for date in range(12):
+            month += 1
+            j_month_fa = jdatetime.date(year=1400, month=month, day=10).strftime("%e")
+            self.assertEqual(j_month_fa, j_months_fa[month - 1])
+
     def test_dates_are_not_equal_if_locales_are_different(self):
         date_fa = jdatetime.date(1397, 4, 22, locale='fa_IR')
         date_nl = jdatetime.date(1397, 4, 22, locale='nl_NL')


### PR DESCRIPTION
Now we have `%B` which gives us `Azar` for example.  

I've added `%E` which gives us `آذر‍` in this case.