### PR TITLE
feat(strptime): handle `%y` and `%f` directives

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -928,7 +928,7 @@ class datetime(date):
 
         year = int(get('Y') or get('y') or 1279)
         if year < 100:  # %y, see the discussion at #100
-            year += (1400 if year <= 68 else 1300)
+            year += 1400 if year <= 68 else 1300
         return datetime(
             year,
             int(get('m', 1)),

--- a/t/test.py
+++ b/t/test.py
@@ -408,6 +408,41 @@ class TestJDateTime(unittest.TestCase):
 
         self.assertEqual(dt1, dt2)
 
+    def test_strptime_special_chars(self):
+        date_string = "[1363*6*6] ? (12+13+14)"
+        date_format = "[%Y*%m*%d] ? (%H+%M+%S)"
+        dt1 = jdatetime.datetime.strptime(date_string, date_format)
+        dt2 = jdatetime.datetime(1363, 6, 6, 12, 13, 14)
+
+        self.assertEqual(dt1, dt2)
+
+    def test_strptime_small_y(self):
+        self.assertEqual(
+            jdatetime.datetime(1468, 1, 1),
+            jdatetime.datetime.strptime("68/1/1", "%y/%m/%d")
+        )
+        self.assertEqual(
+            jdatetime.datetime(1369, 1, 1),
+            jdatetime.datetime.strptime("69/1/1", "%y/%m/%d")
+        )
+
+    def test_strptime_do_not_match_excessive_characters(self):
+        with self.assertRaises(
+            ValueError,
+            msg='%y should not match the trailing space character'
+        ):
+            jdatetime.datetime.strptime('21 ', '%y')
+
+    def test_strptime_nanoseconds(self):
+        self.assertEqual(
+            jdatetime.datetime(1279, 1, 1, 0, 0, 0, 700000),
+            jdatetime.datetime.strptime("7", "%f")
+        )
+        self.assertEqual(
+            jdatetime.datetime(1279, 1, 1, 0, 0, 0, 12300),
+            jdatetime.datetime.strptime("0123", "%f")
+        )
+
     def test_datetime_eq(self):
         date_string = "1363-6-6 12:13:14"
         date_format = "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
Rewrite `strptime` to make the code more clear.

This implementation assumes 14th century for 00 <= %y <= 68
and 13th century for 69 <= %y <= 99.

This patch also fixes a bug in `strptime` where it could not
handle `?` in the format string.

Tests where added.

closes #100