### PR TITLE
feat(strptime): handle `%y` and `%f` directives

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -9,6 +9,7 @@ import platform
 import datetime as py_datetime
 import locale as _locale
 import re as _re
+from functools import partial as _partial
 
 try:
     from greenlet import getcurrent as get_ident
@@ -47,6 +48,16 @@ if platform.system() == 'Windows':
     FA_LOCALE = 'Persian_Iran'
 else:
     FA_LOCALE = 'fa_IR'
+
+
+if sys.version_info[:2] < (3, 7):
+    # Prior to Python 3.7, `%` is escaped by re.escape. We don't want that.
+    def _escape(pattern):
+        if isinstance(pattern, bytes):  # only happens in Python 2
+            pattern = pattern.decode()
+        return _re.escape(pattern).replace(r'\%', '%')
+else:
+    _escape = _re.escape
 
 
 def _format_time(hour, minute, second, microsecond, timespec='auto'):
@@ -653,6 +664,24 @@ date.min = date(MINYEAR, 1, 1)
 """The latest representable date, date(MAXYEAR, 12, 31)."""
 date.max = date(MAXYEAR, 12, 30)
 
+_DIRECTIVE_PATTERNS = {
+    '%Y': '(?P<Y>[0-9]{4})',
+    '%y': '(?P<y>[0-9]{2})',
+    '%m': '(?P<m>[0-9]{1,2})',
+    '%d': '(?P<d>[0-9]{1,2})',
+    '%H': '(?P<H>[0-9]{1,2})',
+    '%M': '(?P<M>[0-9]{1,2})',
+    '%S': '(?P<S>[0-9]{1,2})',
+    '%f': '(?P<f>[0-9]{1,6})',
+}
+
+
+# Replace directives with patterns according to _DIRECTIVE_PATTERNS
+_directives_to_pattern = _partial(
+    _re.compile('|'.join(_DIRECTIVE_PATTERNS)).sub,
+    lambda match: _DIRECTIVE_PATTERNS[match.group()]
+)
+
 
 class datetime(date):
     """datetime(
@@ -893,61 +922,30 @@ class datetime(date):
     @staticmethod
     def strptime(date_string, format):
         """string, format -> new datetime parsed from a string (like time.strptime())"""
-        if '*' in format:
-            format = format.replace("*", "\*")
-        if '+' in format:
-            format = format.replace("+", "\+")
-        if '(' in format or ')' in format:
-            format = format.replace("(", "\(")
-            format = format.replace(")", "\)")
-        if '[' in format or ']' in format:
-            format = format.replace("[", "\[")
-            format = format.replace("]", "\]")
-        result_date = {
-            'day': 1,
-            'month': 1,
-            'year': 1279,
-            'microsecond': 0,
-            'second': 0,
-            'minute': 0,
-            'hour': 0,
-        }
-        apply_order = []
-        format_map = {
-            '%d': ['[0-9]{1,2}', 'day'],
-            '%f': ['[0-9]{1,6}', 'microsecond'],
-            '%H': ['[0-9]{1,2}', 'hour'],
-            '%m': ['[0-9]{1,2}', 'month'],
-            '%M': ['[0-9]{1,2}', 'minute'],
-            '%S': ['[0-9]{1,2}', 'second'],
-            '%Y': ['[0-9]{4}', 'year'],
-        }
-        regex = format
-        find = _re.compile("(%[a-zA-Z])")
+        regex = _directives_to_pattern(_escape(format))
 
-        for form in find.findall(format):
-            if form in format_map:
-                regex = regex.replace(form, "(" + format_map[form][0] + ")")
-                apply_order.append(format_map[form][1])
-        try:
-            p = _re.compile(regex)
-            if not p.match(date_string):
-                raise ValueError()
-            for i, el in enumerate(p.match(date_string).groups()):
-                result_date[apply_order[i]] = int(el)
-            return datetime(
-                result_date['year'],
-                result_date['month'],
-                result_date['day'],
-                result_date['hour'],
-                result_date['minute'],
-                result_date['second'],
-            )
-        except Exception:
+        # Cannot use `fullmatch`, it requires Python 3.4+. Use `$` instead.
+        match = _re.match(regex + '$', date_string)
+        if match is None:
             raise ValueError(
                 "time data '%s' does not match format '%s'" %
                 (date_string, format)
             )
+
+        get = match.groupdict().get
+
+        year = int(get('Y') or get('y') or 1279)
+        if year < 100:  # %y, see the discussion at #100
+            year += 1400 if year <= 68 else 1300
+        return datetime(
+            year,
+            int(get('m', 1)),
+            int(get('d', 1)),
+            int(get('H', 0)),
+            int(get('M', 0)),
+            int(get('S', 0)),
+            None if get('f') is None else int('{0:0<6}'.format(get('f'))),
+        )
 
     def replace(
         self,

--- a/t/test.py
+++ b/t/test.py
@@ -420,6 +420,41 @@ class TestJDateTime(unittest.TestCase):
 
         self.assertEqual(dt1, dt2)
 
+    def test_strptime_special_chars(self):
+        date_string = "[1363*6*6] ? (12+13+14)"
+        date_format = "[%Y*%m*%d] ? (%H+%M+%S)"
+        dt1 = jdatetime.datetime.strptime(date_string, date_format)
+        dt2 = jdatetime.datetime(1363, 6, 6, 12, 13, 14)
+
+        self.assertEqual(dt1, dt2)
+
+    def test_strptime_small_y(self):
+        self.assertEqual(
+            jdatetime.datetime(1468, 1, 1),
+            jdatetime.datetime.strptime("68/1/1", "%y/%m/%d")
+        )
+        self.assertEqual(
+            jdatetime.datetime(1369, 1, 1),
+            jdatetime.datetime.strptime("69/1/1", "%y/%m/%d")
+        )
+
+    def test_strptime_do_not_match_excessive_characters(self):
+        with self.assertRaises(
+            ValueError,
+            msg='%y should not match the trailing space character'
+        ):
+            jdatetime.datetime.strptime('21 ', '%y')
+
+    def test_strptime_nanoseconds(self):
+        self.assertEqual(
+            jdatetime.datetime(1279, 1, 1, 0, 0, 0, 700000),
+            jdatetime.datetime.strptime("7", "%f")
+        )
+        self.assertEqual(
+            jdatetime.datetime(1279, 1, 1, 0, 0, 0, 12300),
+            jdatetime.datetime.strptime("0123", "%f")
+        )
+
     def test_datetime_eq(self):
         date_string = "1363-6-6 12:13:14"
         date_format = "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
Rewrite `strptime` to make the code more clear.

This implementation assumes 14th century for 00 <= %y <= 68
and 13th century for 69 <= %y <= 99.

This patch also fixes a bug in `strptime` where it could not
handle `?` in the format string.

Tests where added.

closes #100
