### PR TITLE
feat(strptime):handle %b and %B directive.

### DIFF
--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -387,11 +387,11 @@ class TestJDateTime(TestCase):
                 self.assertEqual(jdatetime.datetime(1400, 2, 14), date)
 
     def test_strptime_invalid_date_string_b_directive(self):
-        with self.assertRaises(ValueError,msg="time data '14 DRO 1400' does not match format '%d %b %Y'"):
+        with self.assertRaises(ValueError, msg="time data '14 DRO 1400' does not match format '%d %b %Y'"):
             jdatetime.datetime.strptime('14 DRO 1400', '%d %b %Y')
 
     def test_strptime_invalid_date_string_B_directive(self):
-        with self.assertRaises(ValueError,msg="time data '14 ordi 1400' does not match format '%d %B %Y'"):
+        with self.assertRaises(ValueError, msg="time data '14 ordi 1400' does not match format '%d %B %Y'"):
             jdatetime.datetime.strptime('14 ordi 1400', '%d %B %Y')
 
     def test_datetime_eq(self):

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -386,6 +386,14 @@ class TestJDateTime(TestCase):
                 date = jdatetime.datetime.strptime(date_string, date_format)
                 self.assertEqual(jdatetime.datetime(1400, 2, 14), date)
 
+    def test_strptime_invalid_date_string_b_directive(self):
+        with self.assertRaises(ValueError,msg="time data '14 DRO 1400' does not match format '%d %b %Y'"):
+            jdatetime.datetime.strptime('14 DRO 1400', '%d %b %Y')
+
+    def test_strptime_invalid_date_string_B_directive(self):
+        with self.assertRaises(ValueError,msg="time data '14 ordi 1400' does not match format '%d %B %Y'"):
+            jdatetime.datetime.strptime('14 ordi 1400', '%d %B %Y')
+
     def test_datetime_eq(self):
         date_string = "1363-6-6 12:13:14"
         date_format = "%Y-%m-%d %H:%M:%S"

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -357,6 +357,34 @@ class TestJDateTime(TestCase):
             jdatetime.datetime.strptime("0123", "%f")
         )
 
+    def test_strptime_handle_b_B_directive(self):
+        date_format_list = [
+            ('14 Ordibehesht 1400', '%d %B %Y'),
+            ('14 ordibehesht 1400', '%d %B %Y'),
+            ('14 ordiBehesHt 1400', '%d %B %Y'),
+            ('۱۴ Ordibehesht ۱۴۰۰', '%d %B %Y'),
+            ('۱۴ ordibehesht ۱۴۰۰', '%d %B %Y'),
+            ('۱۴ orDibeHesht ۱۴۰۰', '%d %B %Y'),
+            ('1۴ Ordibehesht 14۰۰', '%d %B %Y'),
+            ('۱4 ordibehesht 14۰0', '%d %B %Y'),
+            ('۱4 OrdiBeheshT 14۰0', '%d %B %Y'),
+            ('۱۴ اردیبهشت ۱۴۰۰', '%d %B %Y'),
+            ('14 اردیبهشت 1400', '%d %B %Y'),
+            ('1۴ اردیبهشت ۱4۰0', '%d %B %Y'),
+            ('14 Ord 1400', '%d %b %Y'),
+            ('14 ord 1400', '%d %b %Y'),
+            ('14 oRD 1400', '%d %b %Y'),
+            ('۱۴ Ord ۱۴۰۰', '%d %b %Y'),
+            ('۱۴ ord ۱۴۰۰', '%d %b %Y'),
+            ('۱۴ OrD ۱۴۰۰', '%d %b %Y'),
+            ('۱4 Ord 14۰0', '%d %b %Y'),
+            ('۱4 ord 14۰0', '%d %b %Y'),
+            ('۱4 ORD 14۰0', '%d %b %Y'),
+        ]
+        for date_format in date_format_list:
+            date = jdatetime.datetime.strptime(date_format[0], date_format[1])
+            self.assertEqual(jdatetime.datetime(1400, 2, 14), date)
+
     def test_datetime_eq(self):
         date_string = "1363-6-6 12:13:14"
         date_format = "%Y-%m-%d %H:%M:%S"

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -358,7 +358,7 @@ class TestJDateTime(TestCase):
         )
 
     def test_strptime_handle_b_B_directive(self):
-        date_format_list = [
+        tests = [
             ('14 Ordibehesht 1400', '%d %B %Y'),
             ('14 ordibehesht 1400', '%d %B %Y'),
             ('14 ordiBehesHt 1400', '%d %B %Y'),
@@ -381,9 +381,10 @@ class TestJDateTime(TestCase):
             ('۱4 ord 14۰0', '%d %b %Y'),
             ('۱4 ORD 14۰0', '%d %b %Y'),
         ]
-        for date_format in date_format_list:
-            date = jdatetime.datetime.strptime(date_format[0], date_format[1])
-            self.assertEqual(jdatetime.datetime(1400, 2, 14), date)
+        for date_string, date_format in tests:
+            with self.subTest(date_string=date_string, date_format=date_format):
+                date = jdatetime.datetime.strptime(date_string, date_format)
+                self.assertEqual(jdatetime.datetime(1400, 2, 14), date)
 
     def test_datetime_eq(self):
         date_string = "1363-6-6 12:13:14"


### PR DESCRIPTION
in response to this [issue](https://github.com/slashmili/python-jalali/issues/91)
as I discussed there If patterns are changed to use '\d' instead of [0-9] regex patterns for python 3 can detect Unicode numbers.

to detect month names in the string we can use these patterns.
```
    '%B': '(?P<B>[a-zA-Z\u0600-\u06EF\uFB8A\u067E\u0686\u06AF]{3,12})'
    '%b': '(?P<b>[a-zA-Z]{3})',
```
these patterns detect month names.
I tested it against these examples and it works fine.
```
jdatetime.datetime.strptime('14 Ordibehesht 1400', '%d %B %Y')
jdatetime.datetime.strptime('14 ordibehesht 1400', '%d %B %Y')
jdatetime.datetime.strptime('۱۴ Ordibehesht ۱۴۰۰', '%d %B %Y')
jdatetime.datetime.strptime('۱۴ ordibehesht ۱۴۰۰', '%d %B %Y')
jdatetime.datetime.strptime('1۴ Ordibehesht 14۰۰', '%d %B %Y')
jdatetime.datetime.strptime('۱4 ordibehesht 14۰0', '%d %B %Y')
jdatetime.datetime.strptime('۱۴ اردیبهشت ۱۴۰۰', '%d %B %Y')
jdatetime.datetime.strptime('14 اردیبهشت 1400', '%d %B %Y')
jdatetime.datetime.strptime('1۴ اردیبهشت ۱4۰0', '%d %B %Y')
jdatetime.datetime.strptime('14 Ord 1400', '%d %b %Y')
jdatetime.datetime.strptime('۱۴ Ord ۱۴۰۰', '%d %b %Y')
jdatetime.datetime.strptime('۱4 Ord 14۰0', '%d %b %Y')
```