### PR TITLE
feat(strptime):handle %z directive.

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -1326,7 +1326,8 @@ class datetime(date):
 
     @staticmethod
     def _timezone_from_string(timezone_string):
-        if timezone_string is None: return None
+        if timezone_string is None:
+            return None
         z = timezone_string  # keep the original string for value error exception.
         if z[3] == ':':
             z = z[:3] + z[4:]

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -661,7 +661,6 @@ _DIRECTIVE_PATTERNS = {
     '%z': '(?P<z>[+-]\d\d:?[0-5\u06F0-\u06F5]\d(:?[0-5\u06F0-\u06F5]\d(\.\d{1,6})?)?)',
 }
 
-
 # Replace directives with patterns according to _DIRECTIVE_PATTERNS
 _directives_to_pattern = _partial(
     re.compile('|'.join(_DIRECTIVE_PATTERNS)).sub,
@@ -1327,27 +1326,25 @@ class datetime(date):
 
     @staticmethod
     def _timezone_from_string(timezone_string):
+        if timezone_string is None: return None
         z = timezone_string  # keep the original string for value error exception.
-        if z:
-            if z[3] == ':':
-                z = z[:3] + z[4:]
-                if len(z) > 5:
-                    if z[5] != ':':
-                        msg = f"Inconsistent use of : in {timezone_string}"
-                        raise ValueError(msg)
-                    z = z[:5] + z[6:]
-            hours = int(z[1:3])
-            minutes = int(z[3:5])
-            seconds = int(z[5:7] or 0)
-            gmtoff = (hours * 60 * 60) + (minutes * 60) + seconds
-            gmtoff_remainder = z[8:]
-            # Pad to always return microseconds.
-            gmtoff_remainder_padding = "0" * (6 - len(gmtoff_remainder))
-            gmtoff_fraction = int(gmtoff_remainder + gmtoff_remainder_padding)
-            if z.startswith("-"):
-                gmtoff = -gmtoff
-                gmtoff_fraction = -gmtoff_fraction
-            timezone = py_datetime.timezone(timedelta(seconds=gmtoff, microseconds=gmtoff_fraction))
-        else:
-            timezone = None
+        if z[3] == ':':
+            z = z[:3] + z[4:]
+            if len(z) > 5:
+                if z[5] != ':':
+                    msg = f"Inconsistent use of : in {timezone_string}"
+                    raise ValueError(msg)
+                z = z[:5] + z[6:]
+        hours = int(z[1:3])
+        minutes = int(z[3:5])
+        seconds = int(z[5:7] or 0)
+        gmtoff = (hours * 60 * 60) + (minutes * 60) + seconds
+        gmtoff_remainder = z[8:]
+        # Pad to always return microseconds.
+        gmtoff_remainder_padding = "0" * (6 - len(gmtoff_remainder))
+        gmtoff_fraction = int(gmtoff_remainder + gmtoff_remainder_padding)
+        if z.startswith("-"):
+            gmtoff = -gmtoff
+            gmtoff_fraction = -gmtoff_fraction
+        timezone = py_datetime.timezone(timedelta(seconds=gmtoff, microseconds=gmtoff_fraction))
         return timezone

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -658,6 +658,7 @@ _DIRECTIVE_PATTERNS = {
     '%f': '(?P<f>\d{1,6})',
     '%B': '(?P<B>[a-zA-Z\u0600-\u06EF\uFB8A\u067E\u0686\u06AF]{3,12})',
     '%b': '(?P<b>[a-zA-Z]{3})',
+    '%z': '(?P<z>[+-]\d\d:?[0-5\u06F0-\u06F5]\d(:?[0-5\u06F0-\u06F5]\d(\.\d{1,6})?)?)',
 }
 
 
@@ -942,6 +943,29 @@ class datetime(date):
                     "time data '%s' does not match format '%s'" %
                     (date_string, format)
                 )
+        z = get('z', None)
+        if z:
+            if z[3] == ':':
+                z = z[:3] + z[4:]
+                if len(z) > 5:
+                    if z[5] != ':':
+                        msg = f"Inconsistent use of : in {get('z')}"
+                        raise ValueError(msg)
+                    z = z[:5] + z[6:]
+            hours = int(z[1:3])
+            minutes = int(z[3:5])
+            seconds = int(z[5:7] or 0)
+            gmtoff = (hours * 60 * 60) + (minutes * 60) + seconds
+            gmtoff_remainder = z[8:]
+            # Pad to always return microseconds.
+            gmtoff_remainder_padding = "0" * (6 - len(gmtoff_remainder))
+            gmtoff_fraction = int(gmtoff_remainder + gmtoff_remainder_padding)
+            if z.startswith("-"):
+                gmtoff = -gmtoff
+                gmtoff_fraction = -gmtoff_fraction
+            timezone = py_datetime.timezone(timedelta(seconds=gmtoff, microseconds=gmtoff_fraction))
+        else:
+            timezone = None
         return datetime(
             year,
             month,
@@ -950,6 +974,7 @@ class datetime(date):
             int(get('M', 0)),
             int(get('S', 0)),
             None if get('f') is None else int('{:0<6}'.format(get('f'))),
+            timezone,
         )
 
     def replace(

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -943,29 +943,10 @@ class datetime(date):
                     "time data '%s' does not match format '%s'" %
                     (date_string, format)
                 )
-        z = get('z', None)
-        if z:
-            if z[3] == ':':
-                z = z[:3] + z[4:]
-                if len(z) > 5:
-                    if z[5] != ':':
-                        msg = f"Inconsistent use of : in {get('z')}"
-                        raise ValueError(msg)
-                    z = z[:5] + z[6:]
-            hours = int(z[1:3])
-            minutes = int(z[3:5])
-            seconds = int(z[5:7] or 0)
-            gmtoff = (hours * 60 * 60) + (minutes * 60) + seconds
-            gmtoff_remainder = z[8:]
-            # Pad to always return microseconds.
-            gmtoff_remainder_padding = "0" * (6 - len(gmtoff_remainder))
-            gmtoff_fraction = int(gmtoff_remainder + gmtoff_remainder_padding)
-            if z.startswith("-"):
-                gmtoff = -gmtoff
-                gmtoff_fraction = -gmtoff_fraction
-            timezone = py_datetime.timezone(timedelta(seconds=gmtoff, microseconds=gmtoff_fraction))
-        else:
-            timezone = None
+
+        timezone_string = get('z', None)
+        timezone = datetime._timezone_from_string(timezone_string)
+
         return datetime(
             year,
             month,
@@ -1343,3 +1324,30 @@ class datetime(date):
             tzinfo=self.tzinfo,
             locale=locale,
         )
+
+    @staticmethod
+    def _timezone_from_string(timezone_string):
+        z = timezone_string  # keep the original string for value error exception.
+        if z:
+            if z[3] == ':':
+                z = z[:3] + z[4:]
+                if len(z) > 5:
+                    if z[5] != ':':
+                        msg = f"Inconsistent use of : in {timezone_string}"
+                        raise ValueError(msg)
+                    z = z[:5] + z[6:]
+            hours = int(z[1:3])
+            minutes = int(z[3:5])
+            seconds = int(z[5:7] or 0)
+            gmtoff = (hours * 60 * 60) + (minutes * 60) + seconds
+            gmtoff_remainder = z[8:]
+            # Pad to always return microseconds.
+            gmtoff_remainder_padding = "0" * (6 - len(gmtoff_remainder))
+            gmtoff_fraction = int(gmtoff_remainder + gmtoff_remainder_padding)
+            if z.startswith("-"):
+                gmtoff = -gmtoff
+                gmtoff_fraction = -gmtoff_fraction
+            timezone = py_datetime.timezone(timedelta(seconds=gmtoff, microseconds=gmtoff_fraction))
+        else:
+            timezone = None
+        return timezone


### PR DESCRIPTION
Related to this [issue](https://github.com/slashmili/python-jalali/issues/53#issuecomment-1041601051).
As I said there it can be done how Cpython is handling %z directive. so I added the pattern and remove %Z from it ( right now it still can't handle %Z).
and in strptime added a timezone to create a timezone based on input timedelta.