### PR TITLE
tests(test_zoneinfo_as_timezone): skip if tzinfo is not available on …

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import pathlib
+import pickle
+
+
+def load_pickle(filename):
+    pickle_path = pathlib.Path(__file__).parent / 'pickled_objects' / filename
+    with pickle_path.open('rb') as f:
+        return pickle.load(f)

--- a/tests/test_jdate.py
+++ b/tests/test_jdate.py
@@ -5,6 +5,7 @@ import time
 from unittest import TestCase
 
 import jdatetime
+from tests import load_pickle
 
 
 class TestJDate(TestCase):
@@ -134,8 +135,7 @@ class TestJDate(TestCase):
         else:
             pickled_object_file = 'jdate_py2_jdatetime3.7.pickle'
 
-        with open('tests/pickled_objects/%s' % pickled_object_file, 'rb') as f:
-            d = pickle.load(f)
+        d = load_pickle(pickled_object_file)
         self.assertEqual(d, jdatetime.date(1400, 10, 11))
 
     def test_fromisoformat(self):

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -22,7 +22,7 @@ try:
         # Windows systems, do not have system time zone data available
         # therefore tzdata is required. See:
         # https://docs.python.org/3/library/zoneinfo.html#data-sources
-        import tzinfo
+        import tzinfo as _  # noqa
 except ImportError:
     zoneinfo = None
 

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -18,8 +18,16 @@ except ImportError:
 
 try:
     import zoneinfo
+    if platform.system() == 'Windows':
+        # Windows systems, do not have system time zone data available
+        # therefore tzdata is required. See:
+        # https://docs.python.org/3/library/zoneinfo.html#data-sources
+        import tzinfo
 except ImportError:
     zoneinfo = None
+
+
+from tests import load_pickle
 
 
 class GMTTime(jdatetime.tzinfo):
@@ -753,8 +761,7 @@ class TestJDateTime(TestCase):
         else:
             pickled_object_file = 'jdatetime_py2_jdatetime3.7.pickle'
 
-        with open('tests/pickled_objects/%s' % pickled_object_file, 'rb') as f:
-            dt = pickle.load(f)
+        dt = load_pickle(pickled_object_file)
         self.assertEqual(dt, jdatetime.datetime(1400, 10, 11, 1, 2, 3, 30))
 
 


### PR DESCRIPTION
…windows

On Windows, zoneinfo relies on tzinfo and without it the tests fail with import error.

Also, rewrite pickle file loading.
Previously `open` was using a relative path, which means the path used to depend on the current working directory and could fail if tests were triggered from a wrong directory.
The new load_pickle function will handle that.