### PR TITLE
feat(datetime): implement fromisoformat method

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -341,11 +341,10 @@ class date:
         if not isinstance(date_string, str):
             raise TypeError("fromisoformat: argument must be str")
 
-        iso_format_regex = r"(\d{4})-(\d{2})-(\d{2})"
+        iso_format_regex = r"(\d{4})-?(\d{2})-?(\d{2})"
         matched_str = re.fullmatch(iso_format_regex, date_string)
         if matched_str is not None:
-            y, m, d = list(map(int, date_string.split('-')))
-            return date(y, m, d)
+            return date(*map(int, matched_str.groups()))
         else:
             raise ValueError(f'Invalid isoformat string: {date_string!r}')
 
@@ -811,6 +810,21 @@ class datetime(date):
             now_datetime.minute,
             now_datetime.second,
             now_datetime.microsecond,
+        )
+
+    @classmethod
+    def fromisoformat(cls, date_string: str):
+        """
+        Convert an ISO 8601 formatted string to a jdatetime.date
+        """
+        # Since we do not (yet?) support ISO week dates, the date and time
+        # separator is either at 8th or 10th position, see:
+        # https://github.com/python/cpython/blob/b2b85b5db9cfdb24f966b61757536a898abc3830/Lib/datetime.py#L271
+        separator_position = 10 if date_string[4] == '-' else 8
+        time_string = date_string[separator_position + 1:]
+        return cls.combine(
+            super().fromisoformat(date_string[:separator_position]),
+            time.fromisoformat(time_string) if time_string else time(),
         )
 
     @staticmethod

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -823,7 +823,7 @@ class datetime(date):
         separator_position = 10 if date_string[4] == '-' else 8
         time_string = date_string[separator_position + 1:]
         return cls.combine(
-            super().fromisoformat(date_string[:separator_position]),
+            date.fromisoformat(date_string[:separator_position]),
             time.fromisoformat(time_string) if time_string else time(),
         )
 

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -815,7 +815,7 @@ class datetime(date):
     @classmethod
     def fromisoformat(cls, date_string: str):
         """
-        Convert an ISO 8601 formatted string to a jdatetime.date
+        Convert an ISO 8601 formatted string to a jdatetime.datetime
         """
         # Since we do not (yet?) support ISO week dates, the date and time
         # separator is either at 8th or 10th position, see:

--- a/tests/test_jdate.py
+++ b/tests/test_jdate.py
@@ -144,6 +144,11 @@ class TestJDate(TestCase):
             jdatetime.date(day=22, month=2, year=1378),
         )
 
+        self.assertEqual(  # new Python 3.11 format
+            jdatetime.date.fromisoformat('14020231'),
+            jdatetime.date(1402, 2, 31),
+        )
+
         with self.assertRaises(ValueError, msg="Invalid isoformat string: 'some-invalid-format'"):
             jdatetime.date.fromisoformat("some-invalid-format")
 

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -872,7 +872,7 @@ class TestJdatetimeGetSetLocale(TestCase):
             jdatetime.datetime.fromisoformat('1400-11-04T00:05:23+04:00'),
             jdatetime.datetime(
                 1400, 11, 4, 0, 5, 23, 0,
-                tzinfo=datetime.timezone(datetime.timedelta(seconds=14400))
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=14400)),
             ),
         )
 

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -849,3 +849,45 @@ class TestJdatetimeGetSetLocale(TestCase):
         fa_greenlet.switch(fa_record, jdatetime.FA_LOCALE)
 
         self.assertEqual(['یک‌شنبه', 'خرداد'], fa_record)
+
+    def test_fromisoformat(self):
+        UTC = datetime.timezone.utc
+
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('1402-01-03T15:35:59.898169'),
+            jdatetime.datetime(1402, 1, 3, 15, 35, 59, 898169),
+        )
+
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('1401-11-04 00:05:23.283'),
+            jdatetime.datetime(1401, 11, 4, 0, 5, 23, 283000),
+        )
+
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('1403-11-04 00:05:23.283+00:00'),
+            jdatetime.datetime(1403, 11, 4, 0, 5, 23, 283000, tzinfo=UTC),
+        )
+
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('1400-11-04T00:05:23+04:00'),
+            jdatetime.datetime(
+                1400, 11, 4, 0, 5, 23, 0,
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=14400))
+            ),
+        )
+
+        # new Python 3.11 formats
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('14020101'),
+            jdatetime.datetime(1402, 1, 1),
+        )
+
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('1402-02-31T00:05:23Z'),
+            jdatetime.datetime(1402, 2, 31, 0, 5, 23, 0, tzinfo=UTC),
+        )
+
+        self.assertEqual(
+            jdatetime.datetime.fromisoformat('14031230T010203'),
+            jdatetime.datetime(1403, 12, 30, 1, 2, 3),
+        )

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -876,18 +876,19 @@ class TestJdatetimeGetSetLocale(TestCase):
             ),
         )
 
-        # new Python 3.11 formats
         self.assertEqual(
             jdatetime.datetime.fromisoformat('14020101'),
             jdatetime.datetime(1402, 1, 1),
         )
 
-        self.assertEqual(
-            jdatetime.datetime.fromisoformat('1402-02-31T00:05:23Z'),
-            jdatetime.datetime(1402, 2, 31, 0, 5, 23, 0, tzinfo=UTC),
-        )
+        if sys.version_info[:2] >= (3, 11):  # new Python 3.11 time formats
 
-        self.assertEqual(
-            jdatetime.datetime.fromisoformat('14031230T010203'),
-            jdatetime.datetime(1403, 12, 30, 1, 2, 3),
-        )
+            self.assertEqual(
+                jdatetime.datetime.fromisoformat('1402-02-31T00:05:23Z'),
+                jdatetime.datetime(1402, 2, 31, 0, 5, 23, 0, tzinfo=UTC),
+            )
+
+            self.assertEqual(
+                jdatetime.datetime.fromisoformat('14031230T010203'),
+                jdatetime.datetime(1403, 12, 30, 1, 2, 3),
+            )


### PR DESCRIPTION
Improve `date.isoformat` so it will accept a new Python 3.11
format (with no `-` separator).

Note: I have not implemented ISO week date formats because it looked
too complicated and I have not seen it being used for Solar Hijri dates.

closes #134