### PR TITLE
fix(date, datetime): return NotImplemented for unknown type operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 * BREAKING CHANGE: Arithmetic operations on `date`/`datetime` against an unknown type will now return `NotImplemented` instead of raising `TypeError`
+### Fixed
 * treat %% as an escape sequence in strftime
 
 ## [4.1.1] - 2023-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+* BREAKING CHANGE: Arithmetic operations on `date`/`datetime` against an unknown type will now return `NotImplemented` instead of raising `TypeError`
 * treat %% as an escape sequence in strftime
 
 ## [4.1.1] - 2023-03-28

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -385,10 +385,7 @@ class date:
         """x.__add__(y) <==> x+y"""
         if isinstance(timedelta, py_datetime.timedelta):
             return date.fromgregorian(date=self.togregorian() + timedelta, locale=self.locale)
-        raise TypeError(
-            "unsupported operand type(s) for +: '%s' and '%s'" %
-            (type(self), type(timedelta))
-        )
+        return NotImplemented
 
     def __sub__(self, other):
         """x.__sub__(y) <==> x-y"""
@@ -400,19 +397,13 @@ class date:
         if isinstance(other, date):
             return self.togregorian() - other.togregorian()
 
-        raise TypeError(
-            "unsupported operand type(s) for -: '%s' and '%s'" %
-            (type(self), type(timedelta))
-        )
+        return NotImplemented
 
     def __radd__(self, timedelta):
         """x.__radd__(y) <==> y+x"""
         if isinstance(timedelta, py_datetime.timedelta):
             return self.__add__(timedelta)
-        raise TypeError(
-            "unsupported operand type for +: '%s' and '%s'" %
-            (type(timedelta), type(self))
-        )
+        return NotImplemented
 
     def __rsub__(self, other):
         """x.__rsub__(y) <==> y-x"""
@@ -420,10 +411,7 @@ class date:
             return other.__sub__(self)
         if isinstance(other, py_datetime.date):
             return other - self.togregorian()
-        raise TypeError(
-            "unsupported operand type for -: '%s' and '%s'" %
-            (type(other), type(self))
-        )
+        return NotImplemented
 
     def __eq__(self, other_date):
         """x.__eq__(y) <==> x==y"""
@@ -432,7 +420,7 @@ class date:
         if isinstance(other_date, py_datetime.date):
             return self.__eq__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
-            return False
+            return NotImplemented
         if (
             self.year == other_date.year and
             self.month == other_date.month and
@@ -447,9 +435,7 @@ class date:
         if isinstance(other_date, py_datetime.date):
             return self.__ge__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
-            raise TypeError(
-                "unsupported operand type for >=: '%s'" %
-                (type(other_date)))
+            return NotImplemented
 
         if self.year > other_date.year:
             return True
@@ -465,10 +451,7 @@ class date:
         if isinstance(other_date, py_datetime.date):
             return self.__gt__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
-            raise TypeError(
-                "unsupported operand type for >: '%s'" %
-                (type(other_date))
-            )
+            return NotImplemented
 
         if self.year > other_date.year:
             return True
@@ -484,10 +467,7 @@ class date:
         if isinstance(other_date, py_datetime.date):
             return self.__le__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
-            raise TypeError(
-                "unsupported operand type for <=: '%s'" %
-                (type(other_date))
-            )
+            return NotImplemented
 
         return not self.__gt__(other_date)
 
@@ -496,10 +476,7 @@ class date:
         if isinstance(other_date, py_datetime.date):
             return self.__lt__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
-            raise TypeError(
-                "unsupported operand type for <: '%s'" %
-                (type(other_date))
-            )
+            return NotImplemented
 
         return not self.__ge__(other_date)
 
@@ -510,7 +487,7 @@ class date:
         if isinstance(other_date, py_datetime.date):
             return self.__ne__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
-            return True
+            return NotImplemented
 
         return not self.__eq__(other_date)
 
@@ -1056,9 +1033,7 @@ class datetime(date):
         """x.__add__(y) <==> x+y"""
         if isinstance(timedelta, py_datetime.timedelta):
             return datetime.fromgregorian(datetime=self.togregorian() + timedelta, locale=self.locale)
-        raise TypeError(
-            "unsupported operand type(s) for +: '%s' and '%s'" %
-            (type(self), type(timedelta)))
+        return NotImplemented
 
     def __sub__(self, other):
         """x.__sub__(y) <==> x-y"""
@@ -1069,19 +1044,13 @@ class datetime(date):
             return self.togregorian() - other
         if isinstance(other, datetime):
             return self.togregorian() - other.togregorian()
-        raise TypeError(
-            "unsupported operand type(s) for -: '%s' and '%s'" %
-            (type(self), type(other))
-        )
+        return NotImplemented
 
     def __radd__(self, timedelta):
         """x.__radd__(y) <==> y+x"""
         if isinstance(timedelta, py_datetime.timedelta):
             return self.__add__(timedelta)
-        raise TypeError(
-            "unsupported operand type for +: '%s' and '%s'" %
-            (type(timedelta), type(self))
-        )
+        return NotImplemented
 
     def __rsub__(self, other):
         """x.__rsub__(y) <==> y-x"""
@@ -1089,10 +1058,7 @@ class datetime(date):
             return other.__sub__(self)
         if isinstance(other, py_datetime.datetime):
             return other - self.togregorian()
-        raise TypeError(
-            "unsupported operand type for -: '%s' and '%s'" %
-            (type(other), type(self))
-        )
+        return NotImplemented
 
     def __eq__(self, other_datetime):
         """x.__eq__(y) <==> x==y"""
@@ -1101,7 +1067,7 @@ class datetime(date):
         if isinstance(other_datetime, py_datetime.datetime):
             return self.__eq__(datetime.fromgregorian(datetime=other_datetime))
         if not isinstance(other_datetime, datetime):
-            return False
+            return NotImplemented
         if (
             self.year == other_datetime.year and
             self.month == other_datetime.month and
@@ -1119,10 +1085,7 @@ class datetime(date):
         if isinstance(other_datetime, py_datetime.datetime):
             return self.__ge__(datetime.fromgregorian(datetime=other_datetime))
         if not isinstance(other_datetime, datetime):
-            raise TypeError(
-                "unsupported operand type for >=: '%s'" %
-                (type(other_datetime))
-            )
+            return NotImplemented
 
         return (
             self.year,
@@ -1147,9 +1110,7 @@ class datetime(date):
         if isinstance(other_datetime, py_datetime.datetime):
             return self.__gt__(datetime.fromgregorian(datetime=other_datetime))
         if not isinstance(other_datetime, datetime):
-            raise TypeError(
-                "unsupported operand type for >: '%s'" %
-                (type(other_datetime)))
+            return NotImplemented
 
         return (
             self.year,
@@ -1179,10 +1140,7 @@ class datetime(date):
         if isinstance(other_datetime, py_datetime.datetime):
             return self.__le__(datetime.fromgregorian(datetime=other_datetime))
         if not isinstance(other_datetime, datetime):
-            raise TypeError(
-                "unsupported operand type for <=: '%s'" %
-                (type(other_datetime))
-            )
+            return NotImplemented
 
         return not self.__gt__(other_datetime)
 
@@ -1191,10 +1149,7 @@ class datetime(date):
         if isinstance(other_datetime, py_datetime.datetime):
             return self.__lt__(datetime.fromgregorian(datetime=other_datetime))
         if not isinstance(other_datetime, datetime):
-            raise TypeError(
-                "unsupported operand type for <: '%s'" %
-                (type(other_datetime))
-            )
+            return NotImplemented
         return not self.__ge__(other_datetime)
 
     def __ne__(self, other_datetime):
@@ -1204,7 +1159,7 @@ class datetime(date):
         if isinstance(other_datetime, py_datetime.datetime):
             return self.__ne__(datetime.fromgregorian(datetime=other_datetime))
         if not isinstance(other_datetime, datetime):
-            return True
+            return NotImplemented
 
         return not self.__eq__(other_datetime)
 

--- a/tests/test_jdate.py
+++ b/tests/test_jdate.py
@@ -76,6 +76,23 @@ class TestJDate(TestCase):
         self.assertEqual(new_date.day, 23)
         self.assertEqual(new_date.locale, 'nl_NL')
 
+    def test_unknown_type_operations(self):
+        date = jdatetime.date(1402, 1, 9)
+        unknown_type = object()
+        assert (
+            date.__sub__(unknown_type)
+            is date.__rsub__(unknown_type)
+            is date.__add__(unknown_type)
+            is date.__radd__(unknown_type)
+            is date.__eq__(unknown_type)
+            is date.__ne__(unknown_type)
+            is date.__lt__(unknown_type)
+            is date.__le__(unknown_type)
+            is date.__gt__(unknown_type)
+            is date.__ge__(unknown_type)
+            is NotImplemented
+        )
+
     def test_reverse_add_time_delta(self):
         date = jdatetime.date(1397, 4, 22, locale='nl_NL')
         new_date = datetime.timedelta(days=2) + date

--- a/tests/test_jdate.py
+++ b/tests/test_jdate.py
@@ -92,6 +92,11 @@ class TestJDate(TestCase):
             is date.__ge__(unknown_type)
             is NotImplemented
         )
+        with self.assertRaisesRegex(
+            TypeError,
+            "unsupported operand type\(s\) for \+=: 'date' and 'object'"
+        ):
+            date += unknown_type
 
     def test_reverse_add_time_delta(self):
         date = jdatetime.date(1397, 4, 22, locale='nl_NL')

--- a/tests/test_jdate.py
+++ b/tests/test_jdate.py
@@ -94,7 +94,7 @@ class TestJDate(TestCase):
         )
         with self.assertRaisesRegex(
             TypeError,
-            "unsupported operand type\(s\) for \+=: 'date' and 'object'"
+            r"unsupported operand type\(s\) for \+=: 'date' and 'object'"
         ):
             date += unknown_type
 

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -926,6 +926,6 @@ class TestJdatetimeGetSetLocale(TestCase):
         )
         with self.assertRaisesRegex(
             TypeError,
-            "unsupported operand type\(s\) for \-=: 'datetime' and 'object'"
+            r"unsupported operand type\(s\) for \-=: 'datetime' and 'object'"
         ):
             dt -= unknown_type

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -907,3 +907,20 @@ class TestJdatetimeGetSetLocale(TestCase):
                 jdatetime.datetime.fromisoformat('14031230T010203'),
                 jdatetime.datetime(1403, 12, 30, 1, 2, 3),
             )
+
+    def test_unknown_type_operations(self):
+        dt = jdatetime.datetime(1402, 1, 9)
+        unknown_type = object()
+        self.assertTrue(
+            dt.__sub__(unknown_type)
+            is dt.__rsub__(unknown_type)
+            is dt.__add__(unknown_type)
+            is dt.__radd__(unknown_type)
+            is dt.__eq__(unknown_type)
+            is dt.__ne__(unknown_type)
+            is dt.__lt__(unknown_type)
+            is dt.__le__(unknown_type)
+            is dt.__gt__(unknown_type)
+            is dt.__ge__(unknown_type)
+            is NotImplemented
+        )

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -924,3 +924,8 @@ class TestJdatetimeGetSetLocale(TestCase):
             is dt.__ge__(unknown_type)
             is NotImplemented
         )
+        with self.assertRaisesRegex(
+            TypeError,
+            "unsupported operand type\(s\) for \-=: 'datetime' and 'object'"
+        ):
+            dt -= unknown_type


### PR DESCRIPTION
This is how the built-in `date` and `datetime` work.

closes #84