### PR TITLE
fix appveyor builds by installing current project

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 
 install:
-  - py -m pip install tzdata
+  - py -m pip install . tzdata
 
 test_script:
   - py -m unittest discover tests


### PR DESCRIPTION
running jdatetime requires jalali-core package
which needs to be installed through the requirements.