### PR TITLE
Fix __ne__ for different datetime types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixed
+
+* Fix __ne__ for different datetime types #164
+
 ## [5.1.0] - 2025-01-13
 
 ### Fixed

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -1055,6 +1055,16 @@ class datetime(date):
 
         return self.togregorian() == other_datetime
 
+    def __ne__(self, other_datetime):
+        """x.__ne__(y) <==> x!=y"""
+        if other_datetime is None:
+            return True
+
+        if not (isinstance(other_datetime, datetime) or isinstance(other_datetime, py_datetime.datetime)):
+            return NotImplemented
+
+        return not self.__eq__(other_datetime)
+
     def __ge__(self, other_datetime):
         """x.__ge__(y) <==> x>=y"""
         if isinstance(other_datetime, datetime):

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -481,17 +481,6 @@ class date:
 
         return not self.__ge__(other_date)
 
-    def __ne__(self, other_date):
-        """x.__ne__(y) <==> x!=y"""
-        if other_date is None:
-            return True
-        if isinstance(other_date, py_datetime.date):
-            return self.__ne__(date.fromgregorian(date=other_date))
-        if not isinstance(other_date, date):
-            return NotImplemented
-
-        return not self.__eq__(other_date)
-
     def __hash__(self):
         """x.__hash__() <==> hash(x)"""
         gd = self.togregorian()
@@ -1054,16 +1043,6 @@ class datetime(date):
             return NotImplemented
 
         return self.togregorian() == other_datetime
-
-    def __ne__(self, other_datetime):
-        """x.__ne__(y) <==> x!=y"""
-        if other_datetime is None:
-            return True
-
-        if not (isinstance(other_datetime, datetime) or isinstance(other_datetime, py_datetime.datetime)):
-            return NotImplemented
-
-        return not self.__eq__(other_datetime)
 
     def __ge__(self, other_datetime):
         """x.__ge__(y) <==> x>=y"""

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -763,6 +763,71 @@ class TestJdatetimeComparison(TestCase):
         dt2 = "not a datetime object"
         self.assertFalse(dt1 == dt2)
 
+    # __ne__
+    def test_ne_different_dates(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 0, 0, 0)
+        dt2 = jdatetime.datetime(1403, 1, 2, 0, 0, 0)
+        self.assertTrue(dt1 != dt2)
+
+    def test_neq_different_times(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        dt2 = jdatetime.datetime(1403, 1, 1, 13, 0, 0)
+        self.assertTrue(dt1 != dt2)
+
+    def test_neq_different_timezones(self):
+        gmt = GMTTime()
+        teh = TehranTime()
+
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0, tzinfo=teh)
+        dt2 = jdatetime.datetime(1403, 1, 1, 12, 0, 0, tzinfo=gmt)
+        self.assertTrue(dt1 != dt2)
+
+    def test_neq_same_datetime(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        dt2 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        self.assertFalse(dt1 != dt2)
+
+    def test_neq_different_types(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        self.assertTrue(dt1 != "1403-01-01 12:00:00")
+
+    def test_neq_with_none(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        self.assertTrue(dt1.__ne__(None))
+
+    def test_neq_different_datetime_types(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        dt2 = dt1.togregorian()
+        self.assertFalse(dt1 != dt2)
+
+        # different hour
+        dt2 = dt1.togregorian() + datetime.timedelta(hours=1)
+        self.assertTrue(dt1 != dt2)
+        dt2 = dt1.togregorian() - datetime.timedelta(hours=1)
+        self.assertTrue(dt1 != dt2)
+
+        # different day
+        dt2 = dt1.togregorian() + datetime.timedelta(days=1)
+        self.assertTrue(dt1 != dt2)
+        dt2 = dt1.togregorian() - datetime.timedelta(days=1)
+        self.assertTrue(dt1 != dt2)
+
+        # different month
+        dt2 = dt1.togregorian() + datetime.timedelta(days=31)
+        self.assertTrue(dt1 != dt2)
+        dt2 = dt1.togregorian() - datetime.timedelta(days=31)
+        self.assertTrue(dt1 != dt2)
+
+        # different year
+        dt2 = dt1.togregorian() + datetime.timedelta(days=370)
+        self.assertTrue(dt1 != dt2)
+        dt2 = dt1.togregorian() - datetime.timedelta(days=370)
+        self.assertTrue(dt1 != dt2)
+
+    def test_neq_not_implemented(self):
+        dt1 = jdatetime.datetime(1403, 1, 1, 12, 0, 0)
+        self.assertEqual(dt1.__ne__("not datetime object"), NotImplemented)
+
     # __ge__
     def test_ge_with_same_datetime(self):
         dt1 = jdatetime.datetime(1402, 7, 8, 12, 0, 0)


### PR DESCRIPTION
fix #163 

## Description of Changes

The `__ne__` function in `jdatetime.datetime` was implemented using `__eq__` (`return not self.__eq__(other_datetime)`), ensuring proper handling of comparisons with `datetime.datetime`. This fix correctly returns `True` for unequal types, and tests were added to validate the behavior.

If there are any issues or areas for improvement, please feel free to let me know.
Thanks.