### PR TITLE
Fix: Setuptools License Deprecation Warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,7 +14,8 @@ dependencies = [
 authors = [
     {name = "Milad Rastian", email = "eslashmili@gmail.com"},
 ]
-license = {text = "Python Software Foundation License"}
+license = "PSF-2.0"
+license-files = ["LICENSE"]
 keywords = ["Jalali implementation of Python datetime"]
 urls = {Homepage = "https://github.com/slashmili/python-jalali"}
 


### PR DESCRIPTION
This PR updates the `pyproject.toml` file to resolve a `SetuptoolsDeprecationWarning` that occurs during the build process (`running sdist`).

Rationale for the Change

Setuptools (version 77.0.0+) now deprecates using the `project.license` field as a TOML table (`{text = "..."}`). The build process emits a warning recommending the use of an SPDX expression (a simple string).

Since the LICENSE file indicates the project is under the Python license (specifically, the one used for Python 2.7 and newer), the correct, modern, and non-deprecated SPDX identifier for this license is PSF-2.0 (Python Software Foundation License Version 2).

This ensures future compatibility with Setuptools and Python packaging standards (as outlined in PEP 621 and PEP 639[1]), while maintaining the legal terms of the project's existing license.

[1]: https://peps.python.org/pep-0639/

The error message displayed by setuptools was:

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
````