### PR TITLE
add tzdata to development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,5 @@ lint.extend-select = [
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+    "tzdata>=2025.2; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
tzdata is used in tests and without it tests fail on windows. Windows users can now run `uv run pytest` and uv will handle dependencies correctly and all tests pass.