### PR TITLE
Add `__format__` support for date and datetime classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 build
 *.swp
+venv
 
 .tags
 tags

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -383,6 +383,10 @@ class date:
     def __str__(self):
         return self.strftime('%Y-%m-%d')
 
+    def __format__(self, _format):
+        _format = _format or '%Y-%m-%d'
+        return self.strftime(_format)
+
     def __add__(self, timedelta):
         """x.__add__(y) <==> x+y"""
         if isinstance(timedelta, py_datetime.timedelta):
@@ -547,13 +551,6 @@ class date:
     def isoformat(self):
         """Return a string representing the date in ISO 8601 format, 'YYYY-MM-DD'"""
         return self.strftime('%Y-%m-%d')
-
-    def __format__(self, format):
-        """
-        PEP-3101
-        Make string formating work!
-        """
-        return self.strftime(format)
 
     # strftime helper functions
     def _strftime_get_attr_value(self, attr, fmt, fb=None):
@@ -1200,6 +1197,16 @@ class datetime(date):
             mil = '.' + str(self.microsecond)
         tz = self.strftime('%z')
         return self.strftime('%Y-%m-%d %H:%M:%S') + f'{mil}{tz}'
+
+    def __format__(self, _format):
+        if _format == 's':
+            return str(int(self.timestamp()))
+        if _format == 'f':
+            return str(self.timestamp())
+        if _format:
+            return self.strftime(_format)
+        else:
+            return self.__str__()
 
     def aslocale(self, locale):
         return datetime(

--- a/tests/test_jdate.py
+++ b/tests/test_jdate.py
@@ -184,3 +184,8 @@ class TestJDate(TestCase):
 
         with self.assertRaises(TypeError, msg='fromisoformat: argument must be str'):
             jdatetime.date.fromisoformat(1)
+
+    def test_format(self):
+        d = jdatetime.date(1402, 5, 15)
+        self.assertEqual(f'{d}', '1402-05-15')
+        self.assertEqual(f'{d:%Y/%m/%d}', '1402/05/15')

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -1063,8 +1063,6 @@ class TestJdatetimeGetSetLocale(TestCase):
         ):
             dt -= unknown_type
 
-
-class TestFormat(TestCase):
     def test_date_format(self):
         d = jdatetime.date(1402, 5, 15)
         self.assertEqual(f'{d}', '1402-05-15')

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -1062,3 +1062,17 @@ class TestJdatetimeGetSetLocale(TestCase):
             r"unsupported operand type\(s\) for \-=: 'datetime' and 'object'",
         ):
             dt -= unknown_type
+
+
+class TestFormat(TestCase):
+    def test_date_format(self):
+        d = jdatetime.date(1402, 5, 15)
+        self.assertEqual(f'{d}', '1402-05-15')
+        self.assertEqual(f'{d:%Y/%m/%d}', '1402/05/15')
+
+    def test_datetime_format(self):
+        dt = jdatetime.datetime(1402, 5, 15, 12, 30, 45)
+        self.assertEqual(f'{dt}', '1402-05-15 12:30:45')
+        self.assertEqual(f'{dt:%Y/%m/%d %H:%M}', '1402/05/15 12:30')
+        self.assertIn('.', f'{dt:f}')  # float timestamp
+        self.assertNotIn('.', f'{dt:s}')  # int timestamp


### PR DESCRIPTION
- Edit `__format__` method to `date` class with default format `%Y-%m-%d`
- Edit `__format__` method to `datetime` class with special format specifiers:
  - `'s'` - Unix timestamp as integer
  - `'f'` - Unix timestamp as float
  - Other formats passed to `strftime()`
- Add unit tests for both classes