### PR TITLE
Add Windows test CI support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ${{ matrix.os}}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-    name: OS ${{ matrix.os}} - Python ${{ matrix.python-version }}
+        os: [ ubuntu-latest, windows-latest ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+    name: OS ${{ matrix.os }} - Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -23,9 +23,11 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade tox tox-gh-actions
-          sudo locale-gen fa_IR
+          pip install --upgrade pip
+          pip install --upgrade tox tox-gh-actions
+      - name: Set locale ubuntu
+        if: runner.os == 'Linux'
+        run: sudo locale-gen fa_IR
       - name: Tox tests
         run: |
           tox -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     name: OS ${{ matrix.os }} - Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ build
 *.swp
 
 .tags
+.tox
 tags
 .idea/
 dist
+jdatetime.egg-info
 uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ lint.extend-select = [
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+    "tox>=4.30.3",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ python =
 
 [testenv]
 deps =
-    # There are some tests that need greenlet for run
-    py38: greenlet
+    # Install tzdata for support zoneinfo on Windows
+    tzdata; platform_system == "Windows"
 commands =
     python -m unittest discover tests -v


### PR DESCRIPTION
- Add Windows to CI test matrix.
- Added tox as a development dependency for easier local testing.

This PR can replace #173.
