### PR TITLE
Drop legacy Python 2 bytes support from strftime

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -606,12 +606,6 @@ class date:
         return self.strftime('%m/%d/%y')
 
     def strftime(self, format: str) -> str:
-        # Convert to unicode
-        try:
-            format = format.decode('utf-8')
-        except Exception:
-            pass
-
         def repl(match):
             symbol = match[0]
             if symbol in STRFTIME_MAPPING:

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -232,10 +232,6 @@ class TestJDateTime(TestCase):
                 self.assertEqual(dt.strftime('%b'), expected_short_month)
                 self.assertEqual(dt.strftime('%B'), expected_full_month)
 
-    def test_strftime_unicode(self):
-        s = jdatetime.date(1390, 2, 23)
-        self.assertEqual(s.strftime(b'%a %A'), 'Fri Friday')
-
     def test_strftime_single_digit(self):
         dt = jdatetime.datetime(1390, 2, 3, 4, 5, 6)
         self.assertEqual(


### PR DESCRIPTION
Removes the Python 2 compatibility layer that decoded byte strings in `date.strftime()`. Because the library now targets Python 3.9+, standard string formatting applies, and passing bytes format specifiers is no longer supported.

- Remove redundant `.decode('utf-8')` try/except block in `date.strftime()`
- Remove `test_strftime_unicode` which passed bytes (`b'...'`) to `strftime`