### PR TITLE
Remove default __time = None from datetime

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -664,8 +664,6 @@ class datetime(date):
         year, month, day, [hour, [minute, [seconds, [microsecond, [tzinfo]]]]]
     )-> datetime objects"""
 
-    __time = None
-
     def time(self) -> time:
         """Return time object with same time but with tzinfo=None."""
         return time(self.hour, self.minute, self.second, self.microsecond, fold=self.fold)


### PR DESCRIPTION
Setting `__time` to `None` makes type checkers infer that the attribute is optional, while in reality it is always initialized by `__init__`.

Since `__time` is a private implementation detail, this change is not considered breaking.