### PR TITLE
fix(datetime.dst): pass Gregorian to tzinfo.dst()

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -1179,11 +1179,10 @@ class datetime(date):
         """Return ctime() style string."""
         return self.strftime('%c')
 
-    # TODO: check what this def does !
     def dst(self) -> timedelta | None:
         """Return self.tzinfo.dst(self)"""
         if self.tzinfo:
-            return self.tzinfo.dst(self)
+            return self.tzinfo.dst(self.togregorian())
         return None
 
     def isoformat(self, sep: str = 'T', timespec: str = 'auto') -> str:

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -1087,3 +1087,24 @@ class TestJdatetimeGetSetLocale(TestCase):
     def test_min_max(self):
         assert jdatetime.datetime.max == jdatetime.datetime(9377, 12, 12, 23, 59, 59, 999999)
         assert jdatetime.datetime.min == jdatetime.datetime(1, 1, 1, 0, 0)
+
+    def test_dst_calculation_with_timezone(self):
+        # Let's use America/New_York timezone
+        # In 2026:
+        # July 17 (Jalali: 1405-04-26) is in DST (+1 hour offset)
+        # Dec 17 (Jalali: 1405-09-26) is NOT in DST (0 offset)
+        tz = ZoneInfo('America/New_York')
+
+        # 1. Test during Daylight Saving Time (Summer)
+        summer_jdt = jdatetime.datetime(1405, 4, 26, 12, 0, tzinfo=tz)
+
+        self.assertEqual(summer_jdt.dst(), jdatetime.timedelta(hours=1))
+
+        # 2. Test during Standard Time (Winter)
+        winter_jdt = jdatetime.datetime(1405, 9, 26, 12, 0, tzinfo=tz)
+        self.assertEqual(winter_jdt.dst(), jdatetime.timedelta(0))
+
+    def test_dst_returns_none_without_tz(self):
+        # Naive datetime should return None
+        naive_jdt = jdatetime.datetime(1405, 4, 26, 12, 0)
+        self.assertIsNone(naive_jdt.dst())


### PR DESCRIPTION
Standard timezone libraries and databases expect standard Gregorian datetime objects to resolve DST offsets correctly. Passing a Jalali datetime object (`self`) causes two major issues:
1. It results in silent bugs because the database evaluates rules for the Jalali year (e.g., 1405 AD instead of the converted 2026 AD).
2. It can raise type/attribute errors if strict type-checking is enforced.

This converts the instance to its Gregorian representation using `self.togregorian()` before passing it to `tzinfo.dst()`.

Also:
- Removes the outdated TODO comment on the `dst` method.
- Adds unit tests using zoneinfo to verify DST calculations for both aware and naive jdatetime instances.