### PR TITLE
fix: preserve instance locale in datetime.astimezone()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+* `astimezone()` no longer resets the instance locale to the global default
+
 ## [6.0.1] - 2026-07-15
 
 ### Fixed

--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -1165,7 +1165,7 @@ class datetime(date):
         """tz -> convert to local time in new timezone tz"""
         gdt = self.togregorian()
         gdt = gdt.astimezone(tz)
-        return datetime.fromgregorian(datetime=gdt)
+        return datetime.fromgregorian(datetime=gdt, locale=self.locale)
 
     def ctime(self) -> str:
         """Return ctime() style string."""

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -314,6 +314,17 @@ class TestJDateTime(TestCase):
         args = {'year': 1390, 'month': 12, 'hour': 13}
         self.assertEqual(dt.replace(**args).locale, 'nl_NL')
 
+    def test_astimezone_keeps_locale(self):
+        orig_locale = jdatetime.get_locale()
+        jdatetime.set_locale('en_US')
+        self.addCleanup(jdatetime.set_locale, orig_locale)
+
+        teh = TehranTime()
+        dt = jdatetime.datetime(1397, 8, 17, 7, 54, 28, tzinfo=teh, locale='fa_IR')
+        converted = dt.astimezone(datetime.timezone.utc)
+
+        self.assertEqual(converted.locale, 'fa_IR')
+
     def test_replace_remove_tzinfo(self):
         teh = TehranTime()
         dt = jdatetime.datetime(1397, 8, 17, 7, 54, 28, tzinfo=teh)


### PR DESCRIPTION
## Problem
`jdatetime.datetime.astimezone(tz)` silently drops the instance `locale` and resets it to the global default.

```pycon
>>> import datetime, jdatetime
>>> jdatetime.set_locale('en_US')
>>> teh = datetime.timezone(datetime.timedelta(hours=3, minutes=30))
>>> dt = jdatetime.datetime(1397, 8, 17, 7, 54, 28, tzinfo=teh, locale='fa_IR')
>>> dt.astimezone(datetime.timezone.utc).locale
'en_US'
```

Expected `'fa_IR'`. Confirmed on `main` HEAD `4b461d1`.

## Root cause
`astimezone` rebuilds the result with `datetime.fromgregorian(datetime=gdt)` and does not pass the instance locale (`jdatetime/__init__.py:1176`). Every sibling that round-trips through `fromgregorian` passes it: `__add__` (1009), `__sub__` (1022), `replace` (1002), `combine` (860). `astimezone` is the only outlier.

## Fix
Pass `locale=self.locale`, matching the siblings. One line, no API change.

```diff
-        return datetime.fromgregorian(datetime=gdt)
+        return datetime.fromgregorian(datetime=gdt, locale=self.locale)
```

## How to test
Added `test_astimezone_keeps_locale`, next to `test_replace_keeps_date_locale`. It fails on `main` with `AssertionError: 'en_US' != 'fa_IR'` and passes with this change. Real output:

```
before: astimezone().locale = 'en_US'
after:  astimezone().locale = 'fa_IR'
```

The full suite is green apart from a pre-existing `test_with_fa_locale` that fails with `locale.Error: unsupported locale setting` on machines missing the `fa_IR.UTF-8` system locale. It fails identically on unpatched `main`, so it is unrelated to this change. A CHANGELOG entry is included.

## Backward compatibility
No breaking changes. After `astimezone`, the instance locale is preserved, consistent with `replace`, `combine`, `__add__`, and `__sub__`.

---
Assisted-by: Claude (code generation, reviewed and tested locally)
