### PR TITLE
Adapt to Ruff v0.16 defaults

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -96,7 +96,7 @@ class time(py_datetime.time):
         return f'jdatetime.time({self.hour}, {self.minute}, {self.second})'
 
 
-_thread_local_locales = dict()
+_thread_local_locales = {}
 
 
 def set_locale(locale: str | None) -> str | None:
@@ -138,7 +138,7 @@ class date:
     non-equal date objects, timedelta(days=1)."""
     resolution: _ClassVar[timedelta] = py_datetime.date.resolution
 
-    j_months_en = [
+    j_months_en: _ClassVar = [
         'Farvardin',
         'Ordibehesht',
         'Khordad',
@@ -152,7 +152,7 @@ class date:
         'Bahman',
         'Esfand',
     ]
-    j_months_short_en = [
+    j_months_short_en: _ClassVar = [
         'Far',
         'Ord',
         'Kho',
@@ -166,7 +166,7 @@ class date:
         'Bah',
         'Esf',
     ]
-    j_weekdays_en = [
+    j_weekdays_en: _ClassVar = [
         'Saturday',
         'Sunday',
         'Monday',
@@ -175,7 +175,7 @@ class date:
         'Thursday',
         'Friday',
     ]
-    j_weekdays_short_en = [
+    j_weekdays_short_en: _ClassVar = [
         'Sat',
         'Sun',
         'Mon',
@@ -184,8 +184,8 @@ class date:
         'Thu',
         'Fri',
     ]
-    j_ampm_en = {'PM': 'PM', 'AM': 'AM'}
-    j_months_fa = [
+    j_ampm_en: _ClassVar = {'PM': 'PM', 'AM': 'AM'}
+    j_months_fa: _ClassVar = [
         'فروردین',
         'اردیبهشت',
         'خرداد',
@@ -199,7 +199,7 @@ class date:
         'بهمن',
         'اسفند',
     ]
-    j_months_short_fa = [
+    j_months_short_fa: _ClassVar = [
         'فرو',
         'ارد',
         'خرد',
@@ -213,7 +213,7 @@ class date:
         'بهم',
         'اسف',
     ]
-    j_weekdays_fa = [
+    j_weekdays_fa: _ClassVar = [
         'شنبه',
         'یک‌شنبه',
         'دوشنبه',
@@ -222,7 +222,7 @@ class date:
         'پنج‌شنبه',
         'جمعه',
     ]
-    j_ampm_fa = {'PM': 'بعد از ظهر', 'AM': 'قبل از ظهر'}
+    j_ampm_fa: _ClassVar = {'PM': 'بعد از ظهر', 'AM': 'قبل از ظهر'}
 
     @property
     def year(self) -> int:
@@ -254,9 +254,7 @@ class date:
     __locale = None
 
     def _check_arg(self, value) -> bool:
-        if isinstance(value, int):
-            return True
-        return False
+        return isinstance(value, int)
 
     def __init__(self, year: int, month: int, day: int, **kwargs):
         """date(year, month, day) --> date object"""
@@ -275,9 +273,9 @@ class date:
         if self.__month == 12 and day == 30 and self.isleap():
             # for leap years it's ok to have 30 days in Esfand
             pass
-        elif self.__month == 12 and day == 30 and not self.isleap():
-            raise ValueError('day is out of range for month')
-        elif day > j_days_in_month[self.__month - 1]:
+        elif (
+            self.__month == 12 and day == 30 and not self.isleap() or day > j_days_in_month[self.__month - 1]
+        ):
             raise ValueError('day is out of range for month')
         self.__day = day
         self.__locale = kwargs['locale'] if (kwargs.get('locale')) else get_locale()
@@ -302,9 +300,7 @@ class date:
             return True
         if None not in _locale.getlocale():
             return False
-        if FA_LOCALE in _locale.getdefaultlocale():
-            return True
-        return False
+        return FA_LOCALE in _locale.getdefaultlocale()
 
     def isleap(self) -> bool:
         """check if year is leap year
@@ -456,14 +452,12 @@ class date:
             return self.__eq__(date.fromgregorian(date=other_date))
         if not isinstance(other_date, date):
             return NotImplemented
-        if (
+        return (
             self.year == other_date.year
             and self.month == other_date.month
             and self.day == other_date.day
             and self.locale == other_date.locale
-        ):
-            return True
-        return False
+        )
 
     def __ge__(self, other_date: date, /) -> bool:
         """x.__ge__(y) <==> x>=y"""
@@ -475,10 +469,9 @@ class date:
         if self.year > other_date.year:
             return True
         elif self.year == other_date.year:
-            if self.month > other_date.month:
-                return True
-            elif self.month == other_date.month and self.day >= other_date.day:
-                return True
+            return (
+                self.month > other_date.month or self.month == other_date.month and self.day >= other_date.day
+            )
         return False
 
     def __gt__(self, other_date: date, /) -> bool:
@@ -491,10 +484,9 @@ class date:
         if self.year > other_date.year:
             return True
         elif self.year == other_date.year:
-            if self.month > other_date.month:
-                return True
-            elif self.month >= other_date.month and self.day > other_date.day:
-                return True
+            return (
+                self.month > other_date.month or self.month >= other_date.month and self.day > other_date.day
+            )
         return False
 
     def __le__(self, other_date: date, /) -> bool:
@@ -542,7 +534,7 @@ class date:
     def yday(self) -> int:
         """return day of year"""
         day = 0
-        for i in range(0, self.month - 1):
+        for i in range(self.month - 1):
             day = day + j_days_in_month[i]
         day = day + self.day
         return day

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,9 @@ version = {attr = "jdatetime.__VERSION__"}
 line-length = 110
 format.quote-style = 'single'
 lint.isort.combine-as-imports = true
-lint.extend-select = [
-    'E501', # line-too-long
-    'W605', # invalid-escape-sequence
-    'FA',   # flake8-future-annotations
-    'I',    # isort
-    'UP',   # pyupgrade
+lint.ignore = [
+    'BLE001', # blind-except
+    'DTZ', # flake8-datetimez
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ line-length = 110
 format.quote-style = 'single'
 lint.isort.combine-as-imports = true
 lint.ignore = [
-    'BLE001', # blind-except
     'DTZ', # flake8-datetimez
 ]
 

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -637,7 +637,7 @@ class TestJDateTime(TestCase):
         try:
             import pytz
             from pytz import timezone
-        except Exception:
+        except ImportError:
             pytz = None
         if pytz:
             tehran = timezone('Asia/Tehran')

--- a/tests/test_jdatetime.py
+++ b/tests/test_jdatetime.py
@@ -128,11 +128,11 @@ class TestJDateTime(TestCase):
         self.assertFalse(today <= today - jdatetime.timedelta(days=1))
         self.assertTrue(today + jdatetime.timedelta(days=1) > today)
         self.assertTrue(today + jdatetime.timedelta(days=30) >= today)
-        self.assertTrue(today == today)
-        self.assertFalse(today > today)
-        self.assertFalse(today < today)
-        self.assertTrue(today >= today)
-        self.assertTrue(today <= today)
+        self.assertTrue(today == today)  # noqa: PLR0124
+        self.assertFalse(today > today)  # noqa: PLR0124
+        self.assertFalse(today < today)  # noqa: PLR0124
+        self.assertTrue(today >= today)  # noqa: PLR0124
+        self.assertTrue(today <= today)  # noqa: PLR0124
         not_today = jdatetime.date(today.year, today.month, today.day) + jdatetime.timedelta(days=1)
         self.assertTrue(today != not_today)
 
@@ -444,9 +444,11 @@ class TestJDateTime(TestCase):
             ('+012345123456', '%z', "time data '+012345123456' does not match format '%z'"),
         ]
         for date_string, date_format, msg in tests:
-            with self.subTest(date_string=date_string, date_format=date_format, msg=msg):
-                with self.assertRaises(ValueError, msg=msg):
-                    jdatetime.datetime.strptime(date_string, date_format)
+            with (
+                self.subTest(date_string=date_string, date_format=date_format, msg=msg),
+                self.assertRaises(ValueError, msg=msg),
+            ):
+                jdatetime.datetime.strptime(date_string, date_format)
 
     def test_strptime_A_p_j_directives(self):
         dt = jdatetime.datetime(1401, 2, 3, 4)


### PR DESCRIPTION
Ruff v0.16 enables a number of new lint rules by default. Update the codebase to address the newly reported diagnostics by simplifying boolean expressions, annotating class variables, modernizing a few constructs,
and silencing intentional test patterns where appropriate.

See the Ruff v0.16 announcement for more details:
https://astral.sh/blog/ruff-v0.16.0/